### PR TITLE
Remove BinOpE and use a single term type

### DIFF
--- a/lib/Fregot/Interpreter.hs
+++ b/lib/Fregot/Interpreter.hs
@@ -119,8 +119,8 @@ evalExpr
     :: Handle -> PackageName -> Sugar.Expr SourceSpan
     -> InterpreterM (Eval.Document Eval.Value)
 evalExpr h pkgname expr = do
-    prep <- Prepare.prepareExpr expr
-    eval h pkgname (Eval.evalExpr prep)
+    term <- Prepare.prepareExpr expr
+    eval h pkgname (Eval.evalTerm term)
 
 evalVar
     :: Handle -> SourceSpan -> PackageName -> Var

--- a/lib/Fregot/Sugar.hs
+++ b/lib/Fregot/Sugar.hs
@@ -320,7 +320,7 @@ instance PP.Pretty PP.Sem (ObjectKey a) where
     pretty (RefK _ v a)  = PP.pretty v <> mconcat (map PP.pretty a)
 
 instance PP.Pretty PP.Sem BinOp where
-    pretty bo = PP.punctuation $ case bo of
+    pretty = PP.punctuation . \case
         UnifyO              -> "="
         AssignO             -> ":="
         EqualO              -> "=="


### PR DESCRIPTION
Binary operations get translated to normal function calls during
preparation.