### PR TITLE
Propagate evaluation context in errors

### DIFF
--- a/tests/golden/repl/debug-error.rego
+++ b/tests/golden/repl/debug-error.rego
@@ -1,0 +1,6 @@
+package debug_error
+
+test_crash {
+  x = 1
+  x + "crash"
+}

--- a/tests/golden/repl/debug-error.spec
+++ b/tests/golden/repl/debug-error.spec
@@ -1,0 +1,19 @@
+{
+    "command": "fregot",
+    "arguments": ["repl", "debug-error.rego"],
+    "asserts": [
+        {"exit_code": 0},
+        {"stderr": "${SPEC_NAME}.stderr"},
+        {"stdout": "${SPEC_NAME}.stdout"}
+    ],
+    "stdin": [
+        ":break debug_error.test_crash",
+        "data.debug_error.test_crash",
+        ":stepover",
+        ":stepover",
+        ":where",
+        "x",
+        ":quit",
+        ":quit"
+    ]
+}

--- a/tests/golden/repl/debug-error.stderr
+++ b/tests/golden/repl/debug-error.stderr
@@ -1,0 +1,24 @@
+F u g u e   R E G O   T o o l k i t
+fregot v0.1.0 repl - use :help for usage info
+fregot ([34meval error[0m):
+  "debug-error.rego" (line 5, column 3):
+  builtin type error:
+
+    5|   x + "crash"
+         [31m^^^^^^^^^^^[0m
+
+  Expected number but got string
+
+  Stack trace:
+    rule [33mtest_crash[0m at data.debug_error.test_crash:1:1
+fregot ([34meval error[0m):
+  "debug-error.rego" (line 5, column 3):
+  builtin type error:
+
+    5|   x + "crash"
+         [31m^^^^^^^^^^^[0m
+
+  Expected number but got string
+
+  Stack trace:
+    rule [33mtest_crash[0m at data.debug_error.test_crash:1:1

--- a/tests/golden/repl/debug-error.stdout
+++ b/tests/golden/repl/debug-error.stdout
@@ -1,0 +1,8 @@
+repl% repl% 4|   x = 1
+     [32m^^^^^[0m
+repl(debug)% 5|   x + "crash"
+     [32m^^^^^^^^^^^[0m
+repl(debug)% [32m(debug)[0m error
+repl(error)% repl(error)% x
+= [31m1[0m
+repl(error)% repl% 


### PR DESCRIPTION
This allows us to inspect the environment (e.g., what is this variable?)
when the debugger crashes.