### PR TITLE
builtins: add infix '&', and functions for 'and' and 'or'

### DIFF
--- a/lib/Fregot/Eval/Builtins.hs
+++ b/lib/Fregot/Eval/Builtins.hs
@@ -211,6 +211,7 @@ defaultBuiltins = HMS.fromList
     [ (NamedFunction (BuiltinName "all"),                       builtin_all)
     , (NamedFunction (BuiltinName "any"),                       builtin_any)
     , (NamedFunction (QualifiedName "array" "concat"),          builtin_array_concat)
+    , (NamedFunction (BuiltinName "and"),                       builtin_bin_and)
     , (NamedFunction (BuiltinName "concat"),                    builtin_concat)
     , (NamedFunction (BuiltinName "contains"),                  builtin_contains)
     , (NamedFunction (BuiltinName "count"),                     builtin_count)
@@ -225,6 +226,7 @@ defaultBuiltins = HMS.fromList
     , (NamedFunction (BuiltinName "lower"),                     builtin_lower)
     , (NamedFunction (BuiltinName "max"),                       builtin_max)
     , (NamedFunction (BuiltinName "min"),                       builtin_min)
+    , (NamedFunction (BuiltinName "or"),                        builtin_bin_or)
     , (NamedFunction (BuiltinName "product"),                   builtin_product)
     , (NamedFunction (BuiltinName "re_match"),                  builtin_re_match)
     , (NamedFunction (BuiltinName "replace"),                   builtin_replace)
@@ -242,6 +244,7 @@ defaultBuiltins = HMS.fromList
     , (NamedFunction (BuiltinName "trim"),                      builtin_trim)
     , (NamedFunction (BuiltinName "upper"),                     builtin_upper)
     , (NamedFunction (BuiltinName "union"),                     builtin_union)
+    , (OperatorFunction BinAndO,             builtin_bin_and)
     , (OperatorFunction EqualO,              builtin_equal)
     , (OperatorFunction NotEqualO,           builtin_not_equal)
     , (OperatorFunction LessThanO,           builtin_less_than)
@@ -511,6 +514,10 @@ builtin_divide = Builtin (In (In Out)) $ pure $
 builtin_modulo :: Monad m => Builtin m
 builtin_modulo = Builtin (In (In Out)) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x `Number.mod` y
+
+builtin_bin_and :: Monad m => Builtin m
+builtin_bin_and = Builtin (In (In Out)) $ pure $
+  \(Cons x (Cons y Nil)) -> return $! SetV $ HS.intersection x y
 
 builtin_bin_or :: Monad m => Builtin m
 builtin_bin_or = Builtin (In (In Out)) $ pure $

--- a/lib/Fregot/Parser/Sugar.hs
+++ b/lib/Fregot/Parser/Sugar.hs
@@ -167,7 +167,8 @@ expr = Parsec.buildExpressionParser
       , binary Tok.TGreaterThanOrEqual GreaterThanOrEqualO Parsec.AssocLeft
       ]
 
-    , [ binary Tok.TPipe BinOrO Parsec.AssocLeft ]
+    , [ binary Tok.TBinAnd BinAndO Parsec.AssocLeft ]
+    , [ binary Tok.TPipe   BinOrO  Parsec.AssocLeft ]
 
     , [ binary Tok.TEqual    EqualO    Parsec.AssocLeft
       , binary Tok.TNotEqual NotEqualO Parsec.AssocLeft

--- a/lib/Fregot/Prepare.hs
+++ b/lib/Fregot/Prepare.hs
@@ -308,6 +308,7 @@ prepareBinOp source = \case
     Sugar.TimesO              -> pure TimesO
     Sugar.DivideO             -> pure DivideO
     Sugar.ModuloO             -> pure ModuloO
+    Sugar.BinAndO             -> pure BinAndO
     Sugar.BinOrO              -> pure BinOrO
     Sugar.UnifyO              -> do
         tellError $ Error.mkError "compile" source

--- a/lib/Fregot/Prepare/Ast.hs
+++ b/lib/Fregot/Prepare/Ast.hs
@@ -133,6 +133,7 @@ data BinOp
     | TimesO
     | DivideO
     | ModuloO
+    | BinAndO
     | BinOrO
     deriving (Eq, Generic, Show)
 
@@ -221,6 +222,7 @@ instance PP.Pretty PP.Sem BinOp where
         TimesO              -> "*"
         DivideO             -> "/"
         ModuloO             -> "%"
+        BinAndO             -> "&"
         BinOrO              -> "|"
 
 instance PP.Pretty PP.Sem (With a) where

--- a/lib/Fregot/Sugar.hs
+++ b/lib/Fregot/Sugar.hs
@@ -174,6 +174,7 @@ data BinOp
     | TimesO
     | DivideO
     | ModuloO
+    | BinAndO
     | BinOrO
     deriving (Generic, Show)
 
@@ -333,6 +334,7 @@ instance PP.Pretty PP.Sem BinOp where
         TimesO              -> "*"
         DivideO             -> "/"
         ModuloO             -> "%"
+        BinAndO             -> "&"
         BinOrO              -> "|"
 
 instance PP.Pretty PP.Sem n => PP.Pretty PP.Sem (With a n) where

--- a/tests/rego/sets-01.rego
+++ b/tests/rego/sets-01.rego
@@ -105,3 +105,21 @@ test_set_09_empty {
 test_set_09_nonempty {
     {1, 2, 3} - {1} == {2, 3}
 }
+
+# 10. Binary union/intersection
+
+test_set_10_binary_union {
+    {1, 2} | {2, 3} == {1, 2, 3}
+}
+
+test_set_10_binary_union_as_function {
+    or({1, 2}, {2, 3}) == {1, 2, 3}
+}
+
+test_set_10_binary_intersection {
+    {1, 2} & {2, 3} == {2}
+}
+
+test_set_10_binary_intersection_as_function {
+    and({1, 2}, {2, 3}) == {2}
+}


### PR DESCRIPTION
The latter two might not be the most useful ones, but OPA allows using

    and(set1, set2)

instead of

    set1 & set2

so we should, too. Similarly for '|' == 'or'.