### PR TITLE
Tidy up README and ami_id example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ policy file using a JSON file as input.
 _Tip: You can run this command yourself from the root of this repo!_
 
 This command evaluates the `data.fregot.examples.ami_id.allow` expression from
-`ami_id.rego` using the input file `repl-input.json`:
+`ami_id.rego` using the input file `repl_input.json`:
 
     fregot eval \
-        --input examples/ami_id/repl-input.json \
+        --input examples/ami_id/repl_input.json \
         'data.fregot.examples.ami_id.allow' \
         examples/ami_id/ami_id.rego
 
@@ -651,19 +651,19 @@ Here's an example. Start the REPL with the `--watch` flag:
 
 Load the Rego and input files:
 
-    repl% :load ami_id.rego
-    Loading ami_id.rego...
+    repl% :load examples/ami_id/ami_id.rego
+    Loading examples/ami_id/ami_id.rego...
     Loaded package fregot.examples.ami_id
-    fregot.examples.ami_id% :input repl-input.json
+    fregot.examples.ami_id% :input examples/ami_id/repl_input.json
 
 Now you can make changes to the Rego and/or input files and `fregot`
 automatically reloads them:
 
     fregot.examples.ami_id%
-    Reloaded ami_id.rego
+    Reloaded examples/ami_id/ami_id.rego
 
     fregot.examples.ami_id%
-    Reloaded repl-input.json
+    Reloaded examples/ami_id/repl_input.json
 
 This allows you to evaluate expressions as you like, and they'll automatically
 be up-to-date.
@@ -680,7 +680,7 @@ re-evaluates the expression and prints the evaluation:
     = false
 
     fregot.examples.ami_id%
-    Reloaded repl-input.json
+    Reloaded repl_input.json
     = true
 
 Example Use Case

--- a/examples/ami_id/ami.tf
+++ b/examples/ami_id/ami.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "foo" {
-  ami = "ami-04b762b4289fba92b"
+  ami = "ami-04b9e92b5572fa0d1"
   instance_type = "t2.micro"
 }
 

--- a/examples/ami_id/ami_id.rego
+++ b/examples/ami_id/ami_id.rego
@@ -4,7 +4,7 @@ default allow = false
  
 # Whitelisted AMIs
 approved_amis = {
-  'ami-04b762b4289fba92b', 'ami-0b69ea66ff7391e80'
+  "ami-04b9e92b5572fa0d1", "ami-0b69ea66ff7391e80"
 }
 
 # All AMIs in the input
@@ -26,7 +26,7 @@ allow {
 # This test should allow the specified AMIs
 test_allow {
     allow with input as {"resource_changes": [
-  {"change": {"after": {"ami": "ami-04b762b4289fba92b"}}},
+  {"change": {"after": {"ami": "ami-04b9e92b5572fa0d1"}}},
   {"change": {"after": {"ami": "ami-0b69ea66ff7391e80"}}}
 ]}
 }

--- a/examples/ami_id/repl_input.json
+++ b/examples/ami_id/repl_input.json
@@ -3,7 +3,7 @@
       {
          "change": {
             "after": {
-               "ami": "ami-04b762b4289fba92b"
+               "ami": "ami-04b9e92b5572fa0d1"
                }
          }
       },

--- a/examples/ami_id/test_ami_id_input.rego
+++ b/examples/ami_id/test_ami_id_input.rego
@@ -29,7 +29,7 @@ valid_two_different_amis = {
       {
          "change": {
             "after": {
-               "ami": "ami-04b762b4289fba92b"
+               "ami": "ami-04b9e92b5572fa0d1"
                }
          }
       },
@@ -67,14 +67,14 @@ valid_two_same_amis = {
       {
          "change": {
             "after": {
-               "ami": "ami-04b762b4289fba92b"
+               "ami": "ami-04b9e92b5572fa0d1"
                }
          }
       },
       {
          "change": {
             "after": {
-               "ami": "ami-04b762b4289fba92b"
+               "ami": "ami-04b9e92b5572fa0d1"
                }
          }
       }
@@ -114,7 +114,7 @@ valid_single_ami_from_tf_plan = {
                "provider_name": "aws",
                "schema_version": 1,
                "values": {
-                  "ami": "ami-04b762b4289fba92b",
+                  "ami": "ami-04b9e92b5572fa0d1",
                   "credit_specification": [],
                   "disable_api_termination": null,
                   "ebs_optimized": null,
@@ -146,7 +146,7 @@ valid_single_ami_from_tf_plan = {
             ],
             "before": null,
             "after": {
-               "ami": "ami-04b762b4289fba92b",
+               "ami": "ami-04b9e92b5572fa0d1",
                "credit_specification": [],
                "disable_api_termination": null,
                "ebs_optimized": null,
@@ -216,7 +216,7 @@ valid_single_ami_from_tf_plan = {
                "provider_config_key": "aws",
                "expressions": {
                   "ami": {
-                     "constant_value": "ami-04b762b4289fba92b"
+                     "constant_value": "ami-04b9e92b5572fa0d1"
                   },
                   "instance_type": {
                      "constant_value": "t2.micro"


### PR DESCRIPTION
- Replace single quotes with double quotes in the ami_id example policy
- Swap out one of the whitelisted AMI IDs in the example for a real AMI ID (Ubuntu Server 18.04 LTS) and update tests/input
- Update the paths and output for the example commands in the README