### PR TITLE
Ignore partial rules when grounding packages

### DIFF
--- a/tests/rego/package-05-reify.rego
+++ b/tests/rego/package-05-reify.rego
@@ -1,0 +1,7 @@
+# This is a package that will be "reified".
+package fregot.tests.package_05.reify
+
+number = 1
+
+# Functions are probably ignored.
+double(x) = y {y = x + x}

--- a/tests/rego/package-05.rego
+++ b/tests/rego/package-05.rego
@@ -1,0 +1,12 @@
+# Check that we can "reify" packages into objects.
+package fregot.tests.package_05
+
+test_package_as_object {
+  # Use `array.concat` to basically erase the type of the module.
+  pkgs = array.concat([data.fregot.tests.package_05.reify], [])
+  pkg = pkgs[0]
+
+  pkg == {
+    "number": 1
+  }
+}


### PR DESCRIPTION
Partial rules (aka functions) cannot be grounded (i.e. reified to
concrete objects).  This patch makes sure they are simply ignored rather
than causing errors.