### PR TITLE
Prefer rule over tree indexing

### DIFF
--- a/tests/rego/package-04-a.rego
+++ b/tests/rego/package-04-a.rego
@@ -1,3 +1,5 @@
 package fregot.tests.package_04.pkgs.a
 
 value = 1
+
+departments = {"engineering", "finance"}

--- a/tests/rego/package-04-b.rego
+++ b/tests/rego/package-04-b.rego
@@ -1,3 +1,5 @@
 package fregot.tests.package_04.pkgs.b
 
 value = 2
+
+departments = {"logistics", "human resources"}

--- a/tests/rego/package-04.rego
+++ b/tests/rego/package-04.rego
@@ -1,5 +1,5 @@
 # Check that we can "iterate" over packages.
-# we use fully qualified names here.
+# We use fully qualified names here.
 package fregot.tests.package_04
 
 packages_as_object[pkg] = val {
@@ -8,4 +8,12 @@ packages_as_object[pkg] = val {
 
 test_packages_as_object {
   packages_as_object == {"a": 1, "b": 2}
+}
+
+# Check that indexing into collection rules defined in these packages works as
+# well.
+departments = {d | data.fregot.tests.package_04.pkgs[_].departments[d]}
+
+test_departments {
+  departments == {"engineering", "finance", "logistics", "human resources"}
 }


### PR DESCRIPTION
If we start indexing into a tree; the intermediate value is represented
by a `TreeM` constructor.  We then try to avoid turning this `TreeM`
into a proper object, since doing so means fully evaluating it, which
isn't always necessary.

However, this optimization should not trigger if there is a rule at that
point in the tree; since then we should index into the rule and not the
tree.