### PR TITLE
Indexing `null` should cut not crash

### DIFF
--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -295,9 +295,10 @@ evalRefArg source indexee (Mu WildcardM) = do
         ArrayV a  -> branch [return (muValue val) | val <- V.toList a]
         SetV s -> branch [return (muValue val) | val <- HS.toList s]
         ObjectV o -> branch [return (muValue val) | (_, val) <- HMS.toList o]
+        NullV -> cut
         _ -> raise' source "reference error" $
             "Cannot index" <+> PP.pretty (describeValue gindexee) <+>
-            " using a free variable"
+            "using a free variable"
 
 evalRefArg source indexee (Mu (FreeM unbound)) = do
     gindexee <- ground source indexee
@@ -314,9 +315,10 @@ evalRefArg source indexee (Mu (FreeM unbound)) = do
             [ Unification.bindTerm unbound (muValue key) >> return (muValue val)
             | (key, val) <- HMS.toList o
             ]
+        NullV -> cut
         _ -> raise' source "reference error" $
             "Cannot index" <+> PP.pretty (describeValue gindexee) <+>
-            " using a free variable"
+            "using a free variable"
 
 evalRefArg source indexee idx = do
     gindexee <- ground source indexee

--- a/tests/rego/refs-01.rego
+++ b/tests/rego/refs-01.rego
@@ -9,3 +9,11 @@ access_array_with_key = 1 {
 test_access_array_with_key {
   access_array_with_key with input as {"array": [1, 2, 3]}
 }
+
+input_has_tags {
+  input.tags[_] = _
+}
+
+test_access_null {
+  not input_has_tags with input as {"tags": null}
+}


### PR DESCRIPTION
This fixes an issue where code such as
 
    a = null
    a[_]

would result in a crash rather than the empty set.