### PR TITLE
Fix issue with the scoping of `with`

### DIFF
--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -582,14 +582,15 @@ evalQuery lits0 = case reverse lits0 of
 -- if the literal was a negation that passed.
 evalLiteral :: Literal SourceSpan -> (Value -> EvalM a) -> EvalM a
 evalLiteral lit next
-    | lit ^. literalNegation = localWiths (lit ^. literalWith) $ do
-        negation trueish $
+    | lit ^. literalNegation = do
+        localWiths (lit ^. literalWith) $ negation trueish $
             evalStatement (lit ^. literalStatement) >>=
             ground (lit ^. literalAnn)
         next true
-    | otherwise = localWiths (lit ^. literalWith) $ do
-        v <- evalStatement $ lit ^. literalStatement
-        r <- ground (lit ^. literalAnn) v
+    | otherwise = do
+        r <- localWiths (lit ^. literalWith) $
+            evalStatement (lit ^. literalStatement) >>=
+            ground (lit ^. literalAnn)
         next r
   where
     localWiths []    mx = mx

--- a/tests/rego/with-02.rego
+++ b/tests/rego/with-02.rego
@@ -1,0 +1,12 @@
+# Regression test; scoping of `with` should be limited.
+package fregot.tests.with_02
+
+the_input_size = ret {
+  ret = input.size
+}
+
+test_input_size {
+  size = the_input_size with input as {"size": 5}
+  size == 5
+  not the_input_size
+}


### PR DESCRIPTION
`with` expressions in queries would affect the input for the entirety of
the query; whereas it should only affect the single statement the `with`
is attached to.