### PR TITLE
Type error when assigning satured call

### DIFF
--- a/lib/Fregot/Types/Infer.hs
+++ b/lib/Fregot/Types/Infer.hs
@@ -394,14 +394,14 @@ inferTerm (NameT source (QualifiedName key)) = do
 inferTerm (ArrayT source items) = do
     tys <- traverse (inferNonVoidTerm source) items
     pure $ maybe
-        (Types.arrayOf Types.any, NonEmpty.singleton source)
+        (Types.arrayOf Types.unknown, NonEmpty.singleton source)
         (first Types.arrayOf . mergeSourceTypes)
         (NonEmpty.fromList tys)
 
 inferTerm (SetT source items) = do
     tys <- traverse (inferNonVoidTerm source) items
     pure $ maybe
-        (Types.setOf Types.any, NonEmpty.singleton source)
+        (Types.setOf Types.unknown, NonEmpty.singleton source)
         (first Types.setOf . mergeSourceTypes)
         (NonEmpty.fromList tys)
 

--- a/lib/Fregot/Types/Infer.hs
+++ b/lib/Fregot/Types/Infer.hs
@@ -82,6 +82,7 @@ data TypeError
     | CannotRef SourceSpan SourceType
     | CannotCall SourceSpan Function
     | BuiltinTypeError SourceSpan PP.SemDoc
+    | VoidType SourceSpan SourceSpan
     | InternalError PP.SemDoc
 
 data InferEnv = InferEnv
@@ -146,6 +147,13 @@ fromTypeError = \case
 
     BuiltinTypeError source doc -> Error.mkError sub source
         "Builtin type error" doc
+
+    VoidType source use -> Error.mkMultiError sub "Void type" $
+        [ (,) source $
+            "This expression does not have a result, so it should not" <+>
+            "be assigned or used."
+        , (,) use "However, it used here."
+        ]
 
     InternalError msg -> Error.mkErrorNoMeta sub msg
   where
@@ -319,10 +327,19 @@ inferStatement
     :: Statement SourceSpan -> InferM ()
 inferStatement = \case
     TermS t -> () <$ inferTerm t
-    AssignS _source v t -> do
-        tty <- inferTerm t
+    AssignS source v t -> do
+        tty <- inferNonVoidTerm source t
         Unify.bindTerm v tty
     UnifyS source l r -> unifyTermTerm source l r
+
+inferNonVoidTerm :: SourceSpan -> Term SourceSpan -> InferM SourceType
+inferNonVoidTerm use term = do
+    tty <- inferTerm term
+    case tty of
+        (ty, tsource) | ty == Types.void -> do
+            tellError $ VoidType (NonEmpty.head tsource) use
+            pure (Types.unknown, tsource)
+        _ -> pure tty
 
 inferTerm
     :: Term SourceSpan -> InferM SourceType
@@ -375,22 +392,22 @@ inferTerm (NameT source (QualifiedName key)) = do
             pure (Types.object (Types.Obj stat Nothing), NonEmpty.singleton source)
 
 inferTerm (ArrayT source items) = do
-    tys <- traverse inferTerm items
+    tys <- traverse (inferNonVoidTerm source) items
     pure $ maybe
-        (Types.arrayOf Types.empty, NonEmpty.singleton source)
+        (Types.arrayOf Types.any, NonEmpty.singleton source)
         (first Types.arrayOf . mergeSourceTypes)
         (NonEmpty.fromList tys)
 
 inferTerm (SetT source items) = do
-    tys <- traverse inferTerm items
+    tys <- traverse (inferNonVoidTerm source) items
     pure $ maybe
-        (Types.setOf Types.empty, NonEmpty.singleton source)
+        (Types.setOf Types.any, NonEmpty.singleton source)
         (first Types.setOf . mergeSourceTypes)
         (NonEmpty.fromList tys)
 
 inferTerm (ObjectT source obj) = do
     scalarsOrDynamics <- for obj $ \(keyTerm, valueTerm) -> do
-        valueType <- inferTerm valueTerm
+        valueType <- inferNonVoidTerm source valueTerm
         case keyTerm ^? termToScalar . _2 of
             Just scalar -> return (Left (scalar, valueType))
             _           -> Right . (, valueType) <$> inferTerm keyTerm
@@ -518,20 +535,20 @@ inferTerm (ErrorT source) =
 
 unifyTermTerm
     :: SourceSpan -> Term SourceSpan -> Term SourceSpan -> InferM ()
-unifyTermTerm _ (NameT _ WildcardName)  r                       =
-    void (inferTerm r)  -- This might bind variables!
-unifyTermTerm _ l                       (NameT _ WildcardName)  =
-    void (inferTerm l)
+unifyTermTerm source (NameT _ WildcardName)  r                       =
+    void (inferNonVoidTerm source r)  -- This might bind variables!
+unifyTermTerm source l                       (NameT _ WildcardName)  =
+    void (inferNonVoidTerm source l)
 unifyTermTerm _ (NameT _ (LocalName α)) (NameT _ (LocalName β)) =
     Unify.bindVar α β
 
 unifyTermTerm source lhs rhs = catching
     (\errs -> listToMaybe [() | UnboundVars _ <- errs])
     (do
-        rhsty <- inferTerm rhs
+        rhsty <- inferNonVoidTerm source rhs
         unifyTermType source lhs rhsty)
     (\_ -> do
-        lhsty <- inferTerm lhs
+        lhsty <- inferNonVoidTerm source lhs
         unifyTermType source rhs lhsty)
 
 
@@ -571,9 +588,9 @@ unifyTypeType (τ, l) (σ, r)
         unifyTypeType (τ', l) (σ', r)
 
 unifyTypeType (τ, l) (σ, r)
-    | τ == σ                       = return ()
-    | ρ <- τ ∩ σ, ρ /= Types.empty = return ()
-    | otherwise                    =
+    | τ == σ                      = return ()
+    | ρ <- τ ∩ σ, ρ /= Types.void = return ()
+    | otherwise                   =
         tellError $ NoUnify Nothing (τ, l) (σ, r)
 
 inferBuiltin
@@ -639,10 +656,10 @@ inferCall source name arity args check =
     case checkArity arity args of
         ArityBad got         -> fatal $ ArityMismatch source name arity got
         ArityOk inArgs mbOut -> do
-            inferredArgs <- mapM inferTerm inArgs
+            inferredArgs <- mapM (inferNonVoidTerm source) inArgs
             outTy        <- check inferredArgs
             case mbOut of
                 Nothing -> return (outTy, NonEmpty.singleton source)
                 Just o  -> do
                     unifyTermType source o (outTy, NonEmpty.singleton source)
-                    return (Types.boolean, NonEmpty.singleton source)
+                    return (Types.void, NonEmpty.singleton source)

--- a/lib/Fregot/Types/Internal.hs
+++ b/lib/Fregot/Types/Internal.hs
@@ -20,7 +20,7 @@ module Fregot.Types.Internal
 
       -- Utilities
     , singleton
-    , empty
+    , void
     , any
     , unknown
     , boolean
@@ -193,7 +193,7 @@ union (Union l) (Union r) = Union $ HS.fromList $ foldl' insert (HS.toList r) l
         | otherwise                       = work (e : acc) es elm
 
 unions :: [Type] -> Type
-unions = foldl' union empty
+unions = foldl' union void
 
 (∪) :: Type -> Type -> Type
 (∪) = union
@@ -239,7 +239,7 @@ elemIntersection _ _                   = Nothing
 
 intersectionMaybe :: Type -> Type -> Maybe Type
 intersectionMaybe l r =
-    let lr = intersection l r in if lr == empty then Nothing else Just lr
+    let lr = intersection l r in if lr == void then Nothing else Just lr
 
 intersection :: Type -> Type -> Type
 intersection Universe  r         = r
@@ -271,8 +271,8 @@ singleton = prism'
 scalarType :: Ast.Scalar -> Type
 scalarType = review singleton . scalarElem
 
-empty :: Type
-empty = Union HS.empty
+void :: Type
+void = Union HS.empty
 
 any :: Type
 any = Universe

--- a/tests/golden/types/invalid_void.rego
+++ b/tests/golden/types/invalid_void.rego
@@ -1,0 +1,10 @@
+package void
+
+test_assign_void {
+  x = array.concat([1], [2], out)
+  out == [1, 2]
+}
+
+test_array_void {
+  all([array.concat([1], [2], out)])
+}

--- a/tests/golden/types/invalid_void.stderr
+++ b/tests/golden/types/invalid_void.stderr
@@ -1,0 +1,16 @@
+fregot ([34mtypecheck error[0m):
+  "invalid_arity_assign_out.rego" (line 4, column 7):
+  Void type:
+
+    4|   x = array.concat([1], [2], out)
+             [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+
+  This expression does not have a result, so it should not be assigned or used.
+
+  "invalid_arity_assign_out.rego" (line 4, column 3):
+  Void type:
+
+    4|   x = array.concat([1], [2], out)
+         [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+
+  However, it used here.

--- a/tests/golden/types/invalid_void.stderr
+++ b/tests/golden/types/invalid_void.stderr
@@ -1,5 +1,5 @@
 fregot ([34mtypecheck error[0m):
-  "invalid_arity_assign_out.rego" (line 4, column 7):
+  "invalid_void.rego" (line 4, column 7):
   Void type:
 
     4|   x = array.concat([1], [2], out)
@@ -7,10 +7,27 @@ fregot ([34mtypecheck error[0m):
 
   This expression does not have a result, so it should not be assigned or used.
 
-  "invalid_arity_assign_out.rego" (line 4, column 3):
+  "invalid_void.rego" (line 4, column 3):
   Void type:
 
     4|   x = array.concat([1], [2], out)
          [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+
+  However, it used here.
+
+fregot ([34mtypecheck error[0m):
+  "invalid_void.rego" (line 9, column 8):
+  Void type:
+
+    9|   all([array.concat([1], [2], out)])
+              [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
+
+  This expression does not have a result, so it should not be assigned or used.
+
+  "invalid_void.rego" (line 9, column 7):
+  Void type:
+
+    9|   all([array.concat([1], [2], out)])
+             [31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m
 
   However, it used here.


### PR DESCRIPTION
You can use functions that take arguments, such as `array.concat` in two ways:

1.  `array.concat([1], [2], out)`
2.  `out = array.concat([1], [2])` (alternatively using `:=`)

This makes you wonder what the _return type_ of `array.concat([1], [2], out)`
is.  We used to have a boolean here, that returned whether or not `out` unified
with the result.  However, that allows us to write code as:

    x = array.concat([1], [2], out)

Which is almost always an arity mistake on the programmer's side.  This patch
changes the return type of saturated calls to the _void_ type, so it can't be
assigned or used.