### PR TITLE
Refactor: split up builtins module

### DIFF
--- a/fregot.cabal
+++ b/fregot.cabal
@@ -21,13 +21,18 @@ Library
 
   Exposed-modules:
     Fregot.Arity
+    Fregot.Builtins
+    Fregot.Builtins.Basics
+    Fregot.Builtins.Internal
+    Fregot.Builtins.Json
+    Fregot.Builtins.Regex
+    Fregot.Builtins.Time
     Fregot.Compile.Graph
     Fregot.Compile.Order
     Fregot.Compile.Package
     Fregot.Error
     Fregot.Error.Stack
     Fregot.Eval
-    Fregot.Eval.Builtins
     Fregot.Eval.Cache
     Fregot.Eval.Internal
     Fregot.Eval.Json

--- a/lib/Fregot/Builtins.hs
+++ b/lib/Fregot/Builtins.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE TypeOperators     #-}
+module Fregot.Builtins
+    ( ToVal (..)
+    , FromVal (..)
+
+    , Sig (..)
+
+    , Args (..)
+    , toArgs
+
+    , BuiltinM
+    , BuiltinException (..)
+    , Builtin (..)
+    , ReadyBuiltin
+    , arity
+
+    , Function (..)
+    , Builtins
+    , defaultBuiltins
+    ) where
+
+import qualified Fregot.Builtins.Basics   as Builtins.Basics
+import           Fregot.Builtins.Internal
+import qualified Fregot.Builtins.Json     as Builtins.Json
+import qualified Fregot.Builtins.Regex    as Builtins.Regex
+import qualified Fregot.Builtins.Time     as Builtins.Time
+
+defaultBuiltins :: Builtins IO
+defaultBuiltins =
+    Builtins.Basics.builtins <>
+    Builtins.Json.builtins <>
+    Builtins.Regex.builtins <>
+    Builtins.Time.builtins

--- a/lib/Fregot/Builtins/Internal.hs
+++ b/lib/Fregot/Builtins/Internal.hs
@@ -1,0 +1,217 @@
+-- | Internals that allow you to construct (and run) builtins.
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE TypeOperators     #-}
+module Fregot.Builtins.Internal
+    ( ToVal (..)
+    , FromVal (..)
+
+    -- `ToVal` / `FromVal` helper newtypes.
+    , Collection (..)
+    , (:|:) (..)
+
+    , Sig (..)
+
+    , Args (..)
+    , toArgs
+
+    , BuiltinException (..)
+    , Builtin (..)
+    , ReadyBuiltin
+    , arity
+
+    , Function (..)
+
+    , BuiltinM
+    , throwDoc
+    , throwString
+    , eitherToBuiltinM
+
+    , Builtins
+    ) where
+
+import           Control.Applicative          ((<|>))
+import           Control.Arrow                ((>>>))
+import           Control.Lens                 (preview, review)
+import           Control.Monad.Identity       (Identity)
+import           Control.Monad.Stream         (Stream)
+import           Control.Monad.Stream         as Stream
+import           Data.Hashable                (Hashable)
+import qualified Data.HashMap.Strict          as HMS
+import qualified Data.HashSet                 as HS
+import           Data.Int                     (Int64)
+import qualified Data.Text                    as T
+import qualified Data.Text.Lazy               as TL
+import           Data.Traversable.HigherOrder (HTraversable (..))
+import qualified Data.Vector                  as V
+import           Data.Void                    (Void)
+import           Fregot.Eval.Number           (Number)
+import qualified Fregot.Eval.Number           as Number
+import           Fregot.Eval.Value
+import           Fregot.Prepare.Ast           (Function (..))
+import qualified Fregot.PrettyPrint           as PP
+import qualified Fregot.Types.Builtins        as Ty
+
+class ToVal a where
+    toVal :: a -> Value
+
+instance ToVal Value where
+    toVal = id
+
+instance ToVal T.Text where
+    toVal = Value . StringV
+
+instance ToVal TL.Text where
+    toVal = toVal . TL.toStrict
+
+instance ToVal Number where
+    toVal = Value . NumberV
+
+instance ToVal Int where
+    toVal = toVal . (fromIntegral :: Int -> Int64)
+
+instance ToVal Int64 where
+    toVal = toVal . review Number.int
+
+instance ToVal Double where
+    toVal = toVal . review Number.double
+
+instance ToVal Bool where
+    toVal = Value . BoolV
+
+instance ToVal a => ToVal (V.Vector a) where
+    toVal = Value . ArrayV . fmap toVal
+
+instance ToVal a => ToVal [a] where
+    toVal = toVal . V.fromList
+
+instance ToVal a => ToVal (HS.HashSet a) where
+    toVal = Value . SetV . HS.map toVal
+
+class FromVal a where
+    fromVal :: Value -> Either String a
+
+instance FromVal Value where
+    fromVal = Right
+
+instance FromVal T.Text where
+    fromVal (Value (StringV t)) = Right t
+    fromVal v                   = Left $
+        "Expected string but got " ++ describeValue v
+
+instance FromVal Number where
+    fromVal (Value (NumberV n)) = Right n
+    fromVal v                   = Left $
+        "Expected number but got " ++ describeValue v
+
+instance FromVal Int where
+    fromVal = fmap (fromIntegral :: Int64 -> Int) . fromVal
+
+instance FromVal Int64 where
+    fromVal (Value (NumberV n)) | Just i <- preview Number.int n = Right i
+    fromVal v                                                    = Left $
+        "Expected int but got " ++ describeValue v
+
+instance FromVal Double where
+    fromVal (Value (NumberV n)) | Just d <- preview Number.double n = Right d
+    fromVal v                                                       =
+        Left $ "Expected double but got " ++ describeValue v
+
+instance FromVal Bool where
+    fromVal (Value (BoolV b)) = Right b
+    fromVal v                 = Left $
+        "Expected bool but got " ++ describeValue v
+
+instance FromVal a => FromVal (V.Vector a) where
+    fromVal (Value (ArrayV v)) = traverse fromVal v
+    fromVal v                  = Left $
+        "Expected array but got " ++ describeValue v
+
+instance FromVal a => FromVal [a] where
+    fromVal = fmap V.toList . fromVal
+
+instance (Eq a, FromVal a, Hashable a) => FromVal (HS.HashSet a)  where
+    fromVal (Value (SetV s)) = fmap HS.fromList $ traverse fromVal (HS.toList s)
+    fromVal v                = Left $ "Expected set but got " ++ describeValue v
+
+-- | Sometimes builtins (e.g. `count`) do not take a specific type, but any
+-- sort of collection.
+newtype Collection a = Collection [a]
+
+instance FromVal a => FromVal (Collection a) where
+    fromVal = unValue >>> \case
+        ArrayV  c -> Collection <$> traverse fromVal (V.toList c)
+        SetV    c -> Collection <$> traverse fromVal (HS.toList c)
+        ObjectV c -> Collection <$> traverse (fromVal . snd) (HMS.toList c)
+        v         -> Left $
+            "Expected collection but got " ++ describeValue (Value v)
+
+-- | Either-like type for when we have weird ad-hoc polymorphism.
+data a :|: b = InL a | InR b
+
+instance (ToVal a, ToVal b) => ToVal (a :|: b) where
+    toVal (InL x) = toVal x
+    toVal (InR y) = toVal y
+
+instance (FromVal a, FromVal b) => FromVal (a :|: b) where
+    -- TODO(jaspervdj): We should use a datatype for expected result types, so
+    -- we can join them here nicely and not just return the last error message.
+    fromVal v = (InL <$> fromVal v) <|> (InR <$> fromVal v)
+
+data Sig (i :: [t]) (o :: *) where
+    In  :: FromVal a => Sig i o -> Sig (a ': i) o
+    Out :: ToVal o   => Sig '[] o
+
+data Args (a :: [t]) where
+    Nil  :: Args '[]
+    Cons :: a -> Args as -> Args (a ': as)
+
+-- | TODO (jaspervdj): Use arity check instead?
+toArgs :: Sig t o -> [Value] -> Either String (Args t)
+toArgs Out      []       = return Nil
+toArgs Out      _        = Left "too many arguments supplied"
+toArgs (In _)   []       = Left "not enough arguments supplied"
+toArgs (In sig) (x : xs) = Cons <$> fromVal x <*> toArgs sig xs
+
+data BuiltinException = BuiltinException PP.SemDoc deriving (Show)
+
+type BuiltinM a = Stream BuiltinException Void IO a
+
+eitherToBuiltinM :: Either String a -> BuiltinM a
+eitherToBuiltinM = either throwString return
+
+throwString :: String -> BuiltinM a
+throwString = throwDoc . PP.pretty
+
+throwDoc :: PP.SemDoc -> BuiltinM a
+throwDoc = Stream.throw . BuiltinException
+
+-- | A builtin function and its signature.
+data Builtin m where
+    -- TODO(jaspervdj): BuiltinType and Sig are somewhat redundant.
+    Builtin
+        :: ToVal o
+        => Sig i o -> Ty.BuiltinType i -> m (Args i -> BuiltinM o) -> Builtin m
+
+instance HTraversable Builtin where
+    htraverse f (Builtin sig ty impl) = Builtin sig ty <$> f impl
+
+type ReadyBuiltin = Builtin Identity
+
+arity :: Builtin m -> Int
+arity (Builtin sig _ _) = go 0 sig
+  where
+    go :: Int -> Sig i o -> Int
+    go !acc Out    = acc
+    go !acc (In s) = go (acc + 1) s
+
+type Builtins m = HMS.HashMap Function (Builtin m)

--- a/lib/Fregot/Builtins/Json.hs
+++ b/lib/Fregot/Builtins/Json.hs
@@ -1,0 +1,39 @@
+-- | Json-related builtins.
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Fregot.Builtins.Json
+    ( builtins
+    ) where
+
+import qualified Data.Aeson               as A
+import qualified Data.HashMap.Strict      as HMS
+import qualified Data.Text.Encoding       as T
+import qualified Data.Text.Lazy.Encoding  as TL
+import           Fregot.Builtins.Internal
+import qualified Fregot.Eval.Json         as Json
+import           Fregot.Names
+import           Fregot.Types.Builtins    ((🡒))
+import qualified Fregot.Types.Builtins    as Ty
+import qualified Fregot.Types.Internal    as Ty
+
+builtins :: Builtins IO
+builtins = HMS.fromList
+    [ (NamedFunction (QualifiedName "json.marshal"),   builtin_json_marshal)
+    , (NamedFunction (QualifiedName "json.unmarshal"), builtin_json_unmarshal)
+    ]
+
+builtin_json_marshal :: Monad m => Builtin m
+builtin_json_marshal = Builtin
+    (In Out)
+    (Ty.any 🡒 Ty.out Ty.string) $ pure $
+    \(Cons val Nil) -> case Json.fromValue val of
+        Left err   -> throwDoc err
+        Right json -> return $! TL.decodeUtf8 $! A.encode json
+
+builtin_json_unmarshal :: Monad m => Builtin m
+builtin_json_unmarshal = Builtin
+    (In Out)
+    (Ty.string 🡒 Ty.out Ty.unknown) $ pure $
+    \(Cons str Nil) -> case A.eitherDecodeStrict' (T.encodeUtf8 str) of
+        Left  err -> throwString err
+        Right val -> return $! Json.toValue val

--- a/lib/Fregot/Builtins/Regex.hs
+++ b/lib/Fregot/Builtins/Regex.hs
@@ -1,0 +1,71 @@
+-- | Regex-related builtins.
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Fregot.Builtins.Regex
+    ( builtins
+    ) where
+
+import           Control.Monad.Trans      (liftIO)
+import           Data.Bifunctor           (first)
+import qualified Data.HashMap.Strict      as HMS
+import           Data.IORef               (atomicModifyIORef', newIORef)
+import qualified Data.Text                as T
+import           Fregot.Builtins.Internal
+import           Fregot.Names
+import           Fregot.Types.Builtins    ((🡒))
+import qualified Fregot.Types.Builtins    as Ty
+import qualified Fregot.Types.Internal    as Ty
+import qualified Text.Pcre2               as Pcre2
+
+builtins :: Builtins IO
+builtins = HMS.fromList
+    [ (NamedFunction (QualifiedName "regex.split"), builtin_regex_split)
+    , (NamedFunction (BuiltinName "re_match"),      builtin_re_match)
+    ]
+
+builtin_regex_split :: Builtin IO
+builtin_regex_split = Builtin
+    (In (In Out))
+    (Ty.string 🡒 Ty.string 🡒 Ty.out (Ty.arrayOf Ty.string)) $ do
+    cacheRef <- newIORef HMS.empty
+    pure $
+        -- TODO(jaspervdj): Clean up duplication between this and
+        -- `builtin_re_match`.
+        \(Cons pattern (Cons value Nil)) -> do
+        errOrRegex <- liftIO $ atomicModifyIORef' cacheRef $ \cache ->
+            case HMS.lookup pattern cache of
+                Just errOrRegex -> return errOrRegex
+                Nothing         ->
+                    let errOrRegex = Pcre2.compile pattern in
+                    (HMS.insert pattern errOrRegex cache, errOrRegex)
+
+        eitherToBuiltinM $ do
+            regex <- first show errOrRegex
+            match <- first show (Pcre2.match regex value)
+            return $! split match 0 value
+  where
+    split :: [Pcre2.Match] -> Int -> T.Text -> [T.Text]
+    split [] !_offset remainder = [remainder]
+    split (Pcre2.Match (Pcre2.Range start len) _ : matches) !offset remainder =
+        let (pre, post) = T.splitAt (start - offset) remainder in
+        pre : split matches (start + len) (T.drop len post)
+
+builtin_re_match :: Builtin IO
+builtin_re_match = Builtin
+    (In (In Out))
+    (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.boolean) $ do
+    cacheRef <- newIORef HMS.empty
+    pure $
+        \(Cons pattern (Cons value Nil)) -> do
+        errOrRegex <- liftIO $ atomicModifyIORef' cacheRef $ \cache ->
+            case HMS.lookup pattern cache of
+                Just errOrRegex -> return errOrRegex
+                Nothing         ->
+                    let errOrRegex = Pcre2.compile pattern in
+                    (HMS.insert pattern errOrRegex cache, errOrRegex)
+
+        eitherToBuiltinM $ do
+            regex <- first show errOrRegex
+            match <- first show (Pcre2.match regex value)
+            return $! not $ null match

--- a/lib/Fregot/Builtins/Time.hs
+++ b/lib/Fregot/Builtins/Time.hs
@@ -1,0 +1,58 @@
+-- | Date- and time-related builtins.
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Fregot.Builtins.Time
+    ( builtins
+    ) where
+
+import           Control.Lens             (review)
+import           Control.Monad.Trans      (liftIO)
+import qualified Data.HashMap.Strict      as HMS
+import           Data.Int                 (Int64)
+import qualified Data.Text                as T
+import qualified Data.Time                as Time
+import qualified Data.Time.Clock.POSIX    as Time.POSIX
+import qualified Data.Time.RFC3339        as Time.RFC3339
+import           Fregot.Builtins.Internal
+import qualified Fregot.Eval.Number       as Number
+import           Fregot.Names
+import           Fregot.Prepare.Ast       (Function (..))
+import           Fregot.Types.Builtins    ((🡒))
+import qualified Fregot.Types.Builtins    as Ty
+import qualified Fregot.Types.Internal    as Ty
+
+builtins :: Builtins IO
+builtins = HMS.fromList
+    [ (NamedFunction (QualifiedName "time.now_ns"),           builtin_time_now_ns)
+    , (NamedFunction (QualifiedName "time.date"),             builtin_time_date)
+    , (NamedFunction (QualifiedName "time.parse_rfc3339_ns"), builtin_time_parse_rfc3339_ns)
+    ]
+
+utcToNs :: Time.UTCTime -> Int64
+utcToNs =
+    floor . ((1e9 :: Double) *) . realToFrac . Time.POSIX.utcTimeToPOSIXSeconds
+
+builtin_time_now_ns :: Monad m => Builtin m
+builtin_time_now_ns = Builtin
+    Out
+    (Ty.out Ty.number) $ pure $
+    \Nil -> review Number.int . utcToNs <$> liftIO Time.getCurrentTime
+
+builtin_time_date :: Monad m => Builtin m
+builtin_time_date = Builtin
+    (In Out)
+    (Ty.number 🡒 Ty.out (Ty.arrayOf Ty.number)) $ pure $
+    \(Cons ns Nil) ->
+    let secs      = (fromIntegral $ Number.floor ns) / 1e9
+        utc       = Time.POSIX.posixSecondsToUTCTime secs
+        (y, m, d) = Time.toGregorian (Time.utctDay utc) in
+    return ([fromIntegral y, m, d] :: [Int])
+
+builtin_time_parse_rfc3339_ns :: Monad m => Builtin m
+builtin_time_parse_rfc3339_ns = Builtin
+    (In Out)
+    (Ty.string 🡒 Ty.out Ty.number) $ pure $
+    \(Cons txt Nil) -> case Time.RFC3339.parseTimeRFC3339 txt of
+        Just zoned -> return $! utcToNs $ Time.zonedTimeToUTC zoned
+        Nothing    -> throwString $
+            "Could not parse RFC3339 time: " ++ T.unpack txt

--- a/lib/Fregot/Compile/Package.hs
+++ b/lib/Fregot/Compile/Package.hs
@@ -28,11 +28,11 @@ import qualified Data.HashSet.Extended        as HS
 import           Data.List.NonEmpty.Extended  (NonEmpty (..))
 import           Data.Proxy                   (Proxy (..))
 import           Data.Traversable.HigherOrder (htraverse)
+import           Fregot.Builtins.Internal     (Builtins)
 import           Fregot.Compile.Graph
 import           Fregot.Compile.Order
 import           Fregot.Error                 (Error)
 import qualified Fregot.Error                 as Error
-import           Fregot.Eval.Builtins         (Builtins)
 import           Fregot.Eval.Value            (Value)
 import           Fregot.Names
 import           Fregot.Prepare.Ast

--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -49,8 +49,8 @@ import           Data.Maybe                (catMaybes, fromMaybe)
 import qualified Data.Unification          as Unification
 import qualified Data.Vector.Extended      as V
 import           Fregot.Arity
+import           Fregot.Builtins.Internal
 import           Fregot.Compile.Package    (CompiledRule, valueToCompiledRule)
-import           Fregot.Eval.Builtins
 import qualified Fregot.Eval.Cache         as Cache
 import           Fregot.Eval.Internal
 import           Fregot.Eval.Monad

--- a/lib/Fregot/Eval/Internal.hs
+++ b/lib/Fregot/Eval/Internal.hs
@@ -20,8 +20,8 @@ import qualified Data.HashMap.Strict       as HMS
 import           Data.Unification          (Unification)
 import qualified Data.Unification          as Unification
 import qualified Data.Unique               as Unique
+import           Fregot.Builtins.Internal  (ReadyBuiltin)
 import qualified Fregot.Error.Stack        as Stack
-import           Fregot.Eval.Builtins      (ReadyBuiltin)
 import           Fregot.Eval.Cache         (Cache)
 import           Fregot.Eval.Mu            (Mu)
 import           Fregot.Eval.Value         (InstVar, Value)

--- a/lib/Fregot/Eval/Monad.hs
+++ b/lib/Fregot/Eval/Monad.hs
@@ -63,10 +63,10 @@ import qualified Control.Monad.Stream      as Stream
 import           Control.Monad.Trans       (MonadIO (..))
 import qualified Data.HashMap.Strict       as HMS
 import           Data.List                 (find)
+import           Fregot.Builtins.Internal  (BuiltinException (..))
 import           Fregot.Error              (Error)
 import qualified Fregot.Error              as Error
 import qualified Fregot.Error.Stack        as Stack
-import           Fregot.Eval.Builtins     (BuiltinException (..))
 import           Fregot.Eval.Internal
 import           Fregot.Eval.Value
 import           Fregot.Names

--- a/lib/Fregot/Interpreter.hs
+++ b/lib/Fregot/Interpreter.hs
@@ -71,6 +71,8 @@ import qualified Data.Text.Lazy                  as TL
 import qualified Data.Text.Lazy.Encoding         as TL
 import           Data.Traversable.HigherOrder    (htraverse)
 import qualified Data.Yaml.Extended              as Yaml
+import           Fregot.Builtins                 (Builtin, Builtins,
+                                                  defaultBuiltins)
 import qualified Fregot.Compile.Graph            as Compile
 import           Fregot.Compile.Package          (CompiledRule)
 import qualified Fregot.Compile.Package          as Compile
@@ -78,8 +80,6 @@ import           Fregot.Error                    (Error, catchIO)
 import qualified Fregot.Error                    as Error
 import qualified Fregot.Error.Stack              as Stack
 import qualified Fregot.Eval                     as Eval
-import           Fregot.Eval.Builtins            (Builtin, Builtins,
-                                                  defaultBuiltins)
 import qualified Fregot.Eval.Cache               as Cache
 import qualified Fregot.Eval.Json                as Eval.Json
 import           Fregot.Eval.Monad               (EvalCache)

--- a/lib/Fregot/Names/Renamer.hs
+++ b/lib/Fregot/Names/Renamer.hs
@@ -31,9 +31,9 @@ import qualified Data.HashSet.Extended     as HS
 import           Data.List.Extended        (splits, unsnoc)
 import           Data.Maybe                (listToMaybe, maybeToList)
 import           Data.Traversable          (for)
+import           Fregot.Builtins.Internal  (ReadyBuiltin)
 import           Fregot.Error              (Error)
 import qualified Fregot.Error              as Error
-import           Fregot.Eval.Builtins      (ReadyBuiltin)
 import           Fregot.Names
 import           Fregot.Names.Imports
 import           Fregot.Prepare.Ast        (Function (..), Imports)

--- a/lib/Fregot/Types/Infer.hs
+++ b/lib/Fregot/Types/Infer.hs
@@ -53,10 +53,10 @@ import           Data.Proxy                  (Proxy)
 import           Data.Traversable            (for)
 import qualified Data.Unification            as Unify
 import           Fregot.Arity
+import           Fregot.Builtins.Internal    (Builtin, Builtins)
+import qualified Fregot.Builtins.Internal    as Builtin
 import           Fregot.Error                (Error)
 import qualified Fregot.Error                as Error
-import           Fregot.Eval.Builtins        (Builtin, Builtins)
-import qualified Fregot.Eval.Builtins        as Builtin
 import           Fregot.Names
 import           Fregot.Prepare.Ast
 import           Fregot.Prepare.Lens

--- a/tests/hs/Fregot/Interpreter/Tests.hs
+++ b/tests/hs/Fregot/Interpreter/Tests.hs
@@ -4,22 +4,22 @@ module Fregot.Interpreter.Tests
     ( tests
     ) where
 
-import           Control.Lens            (review, view)
-import           Control.Monad.Identity  (Identity)
-import           Control.Monad.Parachute (runParachuteT)
-import qualified Fregot.Eval             as Eval
-import qualified Fregot.Eval.Builtins    as B
-import qualified Fregot.Eval.Number      as Number
-import qualified Fregot.Eval.Value       as Eval
-import qualified Fregot.Interpreter      as Interpreter
-import           Fregot.Names            (Name (..))
-import qualified Fregot.Repl.Parse       as Repl
-import qualified Fregot.Sources          as Sources
-import qualified Fregot.Types.Builtins   as Types
-import qualified Fregot.Types.Internal   as Types
-import qualified Test.Tasty              as Tasty
-import           Test.Tasty.HUnit        ((@?=))
-import qualified Test.Tasty.HUnit        as Tasty
+import           Control.Lens             (review, view)
+import           Control.Monad.Identity   (Identity)
+import           Control.Monad.Parachute  (runParachuteT)
+import qualified Fregot.Builtins.Internal as B
+import qualified Fregot.Eval              as Eval
+import qualified Fregot.Eval.Number       as Number
+import qualified Fregot.Eval.Value        as Eval
+import qualified Fregot.Interpreter       as Interpreter
+import           Fregot.Names             (Name (..))
+import qualified Fregot.Repl.Parse        as Repl
+import qualified Fregot.Sources           as Sources
+import qualified Fregot.Types.Builtins    as Types
+import qualified Fregot.Types.Internal    as Types
+import qualified Test.Tasty               as Tasty
+import           Test.Tasty.HUnit         ((@?=))
+import qualified Test.Tasty.HUnit         as Tasty
 
 tests :: Tasty.TestTree
 tests = Tasty.testGroup "Fregot.Interpreter.Tests"

--- a/tests/hs/Fregot/Prepare/Dsl.hs
+++ b/tests/hs/Fregot/Prepare/Dsl.hs
@@ -7,7 +7,7 @@ module Fregot.Prepare.Dsl where
 import           Control.Lens              (review, (&), (.~))
 import qualified Data.HashMap.Strict       as HMS
 import           Data.String               (IsString (..))
-import qualified Fregot.Eval.Builtins      as B
+import qualified Fregot.Builtins.Internal  as B
 import           Fregot.Eval.Number        (Number)
 import           Fregot.Lexer.Position     (initPosition)
 import           Fregot.Names


### PR DESCRIPTION
The `Fregot.Eval.Builtins` module was getting rather large.  This
patch splits it up three different parts:

 -  `Fregot.Builtins.Internal` provides the core primitives for constructing
    and running builtins.
 -  The implementations move to submodules:
     *  `Fregot.Builtins.Json`
     *  `Fregot.Builtins.Regex`
     *  `Fregot.Builtins.Time`
     *  `Fregot.Builtins.Basics` (catch-all, we can break it up further)
 -  `Fregot.Builtins` which imports all of these and exports them as a
    convenient set.