### PR TITLE
Loosen restrictions on the LHS of :=

### DIFF
--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -625,10 +625,10 @@ evalStatement (UnifyS source x y) = suspend source $ do
     yv <- evalTerm y
     _  <- unify xv yv
     return muTrue
-evalStatement (AssignS source v x) = suspend source $ do
+evalStatement (AssignS source x y) = suspend source $ do
     xv <- evalTerm x
-    iv <- toInstVar v
-    unify (Mu (FreeM iv)) xv
+    yv <- evalTerm y
+    _  <- unify xv yv
     return muTrue
 evalStatement (TermS e) = suspend (e ^. termAnn) (evalTerm e)
 

--- a/lib/Fregot/Prepare/Ast.hs
+++ b/lib/Fregot/Prepare/Ast.hs
@@ -111,7 +111,7 @@ data Literal a = Literal
 
 data Statement a
     = UnifyS  a (Term a) (Term a)
-    | AssignS a UnqualifiedVar (Term a)
+    | AssignS a (Term a) (Term a)
     | TermS     (Term a)
     deriving (Functor, Show)
 

--- a/lib/Fregot/Prepare/Lens.hs
+++ b/lib/Fregot/Prepare/Lens.hs
@@ -92,7 +92,7 @@ termAnn = lens getAnn setAnn
 statementTerms :: Traversal' (Statement a) (Term a)
 statementTerms f = \case
     UnifyS  a x y -> UnifyS a <$> f x <*> f y
-    AssignS a v x -> AssignS a v <$> f x
+    AssignS a x y -> AssignS a <$> f x <*> f y
     TermS       x -> TermS <$> f x
 
 literalTerms :: Traversal' (Literal a) (Term a)

--- a/lib/Fregot/Types/Infer.hs
+++ b/lib/Fregot/Types/Infer.hs
@@ -327,9 +327,9 @@ inferStatement
     :: Statement SourceSpan -> InferM ()
 inferStatement = \case
     TermS t -> () <$ inferTerm t
-    AssignS source v t -> do
-        tty <- inferNonVoidTerm source t
-        Unify.bindTerm v tty
+    AssignS source l r -> do
+        rt <- inferNonVoidTerm source r
+        unifyTermType source l rt
     UnifyS source l r -> unifyTermTerm source l r
 
 inferNonVoidTerm :: SourceSpan -> Term SourceSpan -> InferM SourceType
@@ -562,6 +562,9 @@ unifyTermType _source (NameT _ (LocalName α)) σ = Unify.bindTerm α σ
 unifyTermType source (ArrayT _ arr) (τ, s)
         | Just σ <- τ ^? Types.singleton . Types._Array =
     for_ arr $ \t -> unifyTermType source t (σ, s)
+unifyTermType source (ArrayT _ arr) (τ, s)
+        | τ == Types.unknown =
+    for_ arr $ \t -> unifyTermType source t (τ, s)
 
 unifyTermType source (SetT _ set) (τ, s)
         | Just σ <- τ ^? Types.singleton . Types._Set =

--- a/tests/rego/builtins-10.rego
+++ b/tests/rego/builtins-10.rego
@@ -25,7 +25,7 @@ test_round_trip_02 {
 }
 
 test_decode_sig_01 {
-  [header, payload, sig] = io.jwt.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhbGljZSJ9.OsFj3QHjXgAhTwL7FQ2xjvJwL8FTwnQ1d3x42SuImH8")
+  [header, payload, sig] := io.jwt.decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhbGljZSJ9.OsFj3QHjXgAhTwL7FQ2xjvJwL8FTwnQ1d3x42SuImH8")
   header == {"alg": "HS256", "typ": "JWT"}
   payload == {"iss": "alice"}
   sig == "3ac163dd01e35e00214f02fb150db18ef2702fc153c27435777c78d92b88987f"

--- a/tests/rego/unify-01.rego
+++ b/tests/rego/unify-01.rego
@@ -4,3 +4,8 @@ test_unify_01 {
   to_number(num) == 1234
   split("routes.1234.cidr_block", ".", [_, num, _])
 }
+
+test_unify_02 {
+  [_, num, _] := json.unmarshal("[1, 2, 3]")
+  num == 2
+}


### PR DESCRIPTION
This patch allows arrays as well as variables.