### PR TITLE
Add support for declaring rules using `:=`

### DIFF
--- a/lib/Fregot/Names/Renamer.hs
+++ b/lib/Fregot/Names/Renamer.hs
@@ -110,6 +110,7 @@ renameRuleHead :: Rename RuleHead
 renameRuleHead rh = RuleHead
     <$> pure (rh ^. ruleAnn)
     <*> pure (rh ^. ruleDefault)
+    <*> pure (rh ^. ruleAssign)
     <*> pure (rh ^. ruleName)
     <*> traverse (traverse renameTerm) (rh ^. ruleArgs)
     <*> traverse renameTerm (rh ^. ruleIndex)

--- a/lib/Fregot/Parser/Sugar.hs
+++ b/lib/Fregot/Parser/Sugar.hs
@@ -107,9 +107,11 @@ parseRuleHead = withSourceSpan $ do
         t <- term
         expectToken Tok.TRBracket
         return t
-    _ruleValue <- Parsec.optionMaybe $ do
-        Tok.symbol Tok.TUnify
-        term
+    (_ruleAssign, _ruleValue) <- Parsec.choice
+        [ Tok.symbol Tok.TAssign >> (,) True . Just <$> term
+        , Tok.symbol Tok.TUnify >> (,) False . Just <$> term
+        , pure (False, Nothing)
+        ]
     return $ \_ruleAnn -> RuleHead {..}
 
 parseRuleBody :: FregotParser (RuleBody SourceSpan Var)

--- a/lib/Fregot/Prepare/Ast.hs
+++ b/lib/Fregot/Prepare/Ast.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE TemplateHaskell            #-}
 module Fregot.Prepare.Ast
     ( RuleKind (..), _CompleteRule, _GenSetRule, _GenObjectRule, _FunctionRule
-    , Rule (..), rulePackage, ruleName, ruleKey, ruleAnn, ruleDefault, ruleKind
-    , ruleInfo, ruleDefs
+    , Rule (..), rulePackage, ruleName, ruleKey, ruleAnn, ruleDefault
+    , ruleAssign, ruleKind, ruleInfo, ruleDefs
     , Rule'
     , RuleDefinition (..), ruleDefName, ruleDefImports, ruleDefAnn, ruleArgs
     , ruleIndex, ruleValue, ruleBodies, ruleElses
@@ -76,6 +76,7 @@ data Rule i a = Rule
     , _ruleKind    :: !RuleKind
     , _ruleInfo    :: !i
     , _ruleDefault :: !(Maybe (Term a))
+    , _ruleAssign  :: !Bool
     , _ruleDefs    :: [RuleDefinition a]
     } deriving (Functor, Show)
 
@@ -274,6 +275,7 @@ termToRule source pkgname var t = Rule
     , _ruleKind    = CompleteRule
     , _ruleInfo    = ()
     , _ruleDefault = Nothing
+    , _ruleAssign  = False
     , _ruleDefs    = pure RuleDefinition
         { _ruleDefName    = var
         , _ruleDefImports = mempty

--- a/lib/Fregot/Prepare/Lens.hs
+++ b/lib/Fregot/Prepare/Lens.hs
@@ -37,6 +37,7 @@ ruleTerms f rule = Rule
     <*> pure (rule ^. ruleKind)
     <*> pure (rule ^. ruleInfo)
     <*> traverse f (rule ^. ruleDefault)
+    <*> pure (rule ^. ruleAssign)
     <*> traverseOf (traverse . ruleDefinitionTerms) f (rule ^. ruleDefs)
 
 -- | All direct terms of a rule definition, combine with 'cosmos' to traverse

--- a/lib/Fregot/Sugar.hs
+++ b/lib/Fregot/Sugar.hs
@@ -24,7 +24,7 @@ module Fregot.Sugar
 
     , Rule (..), ruleHead, ruleBodies
     , RuleHead (..), ruleAnn, ruleDefault, ruleName, ruleArgs, ruleIndex
-    , ruleValue, ruleElses
+    , ruleAssign, ruleValue, ruleElses
     , RuleBody, Query
     , RuleElse (..), ruleElseAnn, ruleElseValue, ruleElseBody
     , RuleStatement (..), _VarDeclS, _LiteralS
@@ -102,6 +102,9 @@ instance (Binary a, Binary n) => Binary (Rule a n)
 data RuleHead a n = RuleHead
     { _ruleAnn     :: !a
     , _ruleDefault :: !Bool
+    , -- | If a rule is declared using `:=`, we consider it "assigned", and we
+      -- will only allow a single definition.
+      _ruleAssign  :: !Bool
     , _ruleName    :: !UnqualifiedVar
     , _ruleArgs    :: !(Maybe [Term a n])
     , _ruleIndex   :: !(Maybe (Term a n))

--- a/tests/golden/invalid/assign-rule-01.rego
+++ b/tests/golden/invalid/assign-rule-01.rego
@@ -1,0 +1,11 @@
+package fregot.tests.invalid.assign_rule_01
+
+# Cannot use `:=` with `default`
+default allow := false
+
+# Cannot use multiple `:=`
+pi := 3.14
+pi = 3.14
+
+# Functions should not use `:=`
+double(x) := ret {ret := x + x}

--- a/tests/golden/invalid/assign-rule-01.rego.stderr
+++ b/tests/golden/invalid/assign-rule-01.rego.stderr
@@ -1,0 +1,34 @@
+fregot ([34mcompile error[0m):
+  "assign-rule-01.rego" (line 4, column 1):
+  bad default:
+
+    4| default allow := false
+       [31m^^^^^^^^^^^^^^^^^^^^^^[0m
+
+  Default rules should use `=` rather than `:=`.
+
+fregot ([34mcompile error[0m):
+  "assign-rule-01.rego" (line 8, column 1):
+  conflicting `:=` rule:
+
+    8| pi = 3.14
+       [31m^^^^^^^^^[0m
+
+  rules declared using `:=` cannot have multiple definitions
+
+  "assign-rule-01.rego" (line 7, column 1):
+  conflicting `:=` rule:
+
+    7| pi := 3.14
+       [31m^^^^^^^^^^[0m
+
+  rules declared using `:=` cannot have multiple definitions
+
+fregot ([34mcompile error[0m):
+  "assign-rule-01.rego" (line 11, column 1):
+  bad assignment:
+
+    11| double(x) := ret {ret := x + x}
+        [31m^^^^^^^^^^^^^^^^[0m
+
+  Functions should use `=` rather than `:=`.

--- a/tests/rego/assign-rule-01.rego
+++ b/tests/rego/assign-rule-01.rego
@@ -1,0 +1,16 @@
+package fregot.tests.assign_rule_01
+
+pi := 3.14
+
+allow := true {
+  input.age >= 18
+}
+
+test_pi {
+  pi == 3.14
+}
+
+test_allow {
+  allow with input as {"age": 20}
+  not allow with input as {"age": 17}
+}


### PR DESCRIPTION
These rules have an "assigned" bit set and cannot have multiple definitions.