### PR TITLE
Some uses `,` not `.` for multiple declarations

### DIFF
--- a/lib/Fregot/Parser/Sugar.hs
+++ b/lib/Fregot/Parser/Sugar.hs
@@ -161,7 +161,7 @@ ruleStatement :: FregotParser (RuleStatement SourceSpan Var)
 ruleStatement =
     (withSourceSpan $ do
         Tok.symbol Tok.TSome
-        vars <- Parsec.sepBy1 var (Tok.symbol Tok.TPeriod)
+        vars <- Parsec.sepBy1 var (Tok.symbol Tok.TComma)
         return $ \ann -> VarDeclS ann vars) <|>
      (LiteralS <$> literal)
 

--- a/tests/rego/some-02.rego
+++ b/tests/rego/some-02.rego
@@ -1,0 +1,8 @@
+package fregot.tests.some_02
+
+x := { "foo", "bar" }
+
+allow {
+  some a, b
+  x[a] == x[b]
+}


### PR DESCRIPTION
Fixes #219 