### PR TITLE
Rewrite `==` as just `=`

### DIFF
--- a/lib/Fregot/Builtins/Basics.hs
+++ b/lib/Fregot/Builtins/Basics.hs
@@ -85,7 +85,6 @@ builtins = HMS.fromList
     , (NamedFunction (BuiltinName "union"),            builtin_union)
     , (NamedFunction (BuiltinName "walk"),             builtin_walk)
     , (OperatorFunction BinAndO,             builtin_bin_and)
-    , (OperatorFunction EqualO,              builtin_equal)
     , (OperatorFunction NotEqualO,           builtin_not_equal)
     , (OperatorFunction LessThanO,           builtin_less_than)
     , (OperatorFunction LessThanOrEqualO,    builtin_less_than_or_equal)
@@ -397,19 +396,6 @@ builtin_walk = Builtin
             SetV   s  -> foldMap (\v -> walk (path <> [v]) v) s
             ObjectV o -> ifoldMap (\k -> walk (path <> [toVal k])) o
             _         -> mempty)
-
-builtin_equal :: Monad m => Builtin m
-builtin_equal = Builtin
-  (In (In Out))
-  (\c (Ty.Cons x (Ty.Cons y Ty.Nil)) -> Ty.bcUnify c x y >> pure Ty.boolean)
-  $ pure $
-  -- TODO(jaspervdj): These don't currently work:
-  --
-  --     0 == 1.2 - 1.2
-  --
-  -- Because we'll end up comparing an IntV on the left with a DoubleV on the
-  -- right.
-  \(Cons x (Cons y Nil)) -> return $! Value $ BoolV $! x == (y :: Value)
 
 builtin_not_equal :: Monad m => Builtin m
 builtin_not_equal = Builtin

--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -265,7 +265,7 @@ evalBuiltin source builtin@(Builtin sig _ (Identity impl)) args0 = do
     case mbFinalArg of
         Nothing -> return result
         Just fa -> do
-            unify (Mu (GroundedM result)) fa
+            unify source (Mu (GroundedM result)) fa
             return true
 
 
@@ -283,10 +283,10 @@ evalRefArg _ (Mu (TreeM e p tree)) (Mu WildcardM)
     | (v, t) <- Tree.children tree
     ]
 
-evalRefArg _ (Mu (TreeM e p tree)) (Mu (FreeM unbound))
+evalRefArg source (Mu (TreeM e p tree)) (Mu (FreeM unbound))
         | Nothing <- Tree.root tree = branch
     [ do
-        Unification.bindTerm unbound (muValueF $ StringV $ unVar v)
+        Unification.bindTerm source unbound (muValueF $ StringV $ unVar v)
         pure $! Mu $ TreeM e (p <> review varFromKey v) t
     | (v, t) <- Tree.children tree
     ]
@@ -303,15 +303,17 @@ evalRefArg source indexee (Mu (FreeM unbound)) = do
     gindexee <- ground source indexee
     case unValue gindexee of
         ArrayV a -> branch
-            [ Unification.bindTerm unbound (muValueF $ NumberV $ review Number.int i) >> return (muValue val)
+            [ Unification.bindTerm source unbound
+                (muValueF $ NumberV $ review Number.int i) >>
+                return (muValue val)
             | (i, val) <- zip [0 :: Int64 ..] (V.toList a)
             ]
         SetV s -> branch
-            [ Unification.bindTerm unbound (muValue val) >> return (muValue val)
+            [ Unification.bindTerm source unbound (muValue val) >> return (muValue val)
             | val <- HS.toList s
             ]
         ObjectV o -> branch
-            [ Unification.bindTerm unbound (muValue key) >> return (muValue val)
+            [ Unification.bindTerm source unbound (muValue key) >> return (muValue val)
             | (key, val) <- HMS.toList o
             ]
         _ -> cut
@@ -429,8 +431,8 @@ evalCompiledRule callerSource crule mbIndex
                     (do
                         (k, v) <- HMS.toList partial
                         pure $ case rkind of
-                            GenSetRule -> unify idx (muValue k) >> return k
-                            _          -> unify idx (muValue k) >> return v) ++
+                            GenSetRule -> unify callerSource idx (muValue k) >> return k
+                            _          -> unify callerSource idx (muValue k) >> return v) ++
                     -- Then unknown ones.
                     map (fmap snd) more
 
@@ -478,7 +480,7 @@ evalRuleDefinition callerSource rule mbIndex =
         (Nothing, Nothing) -> return Nothing
         (Just arg, Just tpl) -> do
             tplv <- evalTerm tpl
-            _    <- unify arg tplv
+            _    <- unify callerSource arg tplv
             return $ Just tplv
         (Just _, Nothing) -> raise' callerSource "arity problem" $
             "An argument was given for rule" <+>
@@ -536,7 +538,7 @@ evalUserFunction callerSource crule callerArgs =
         clearLocals $ do
         -- TODO(jaspervdj): Check arity.
         calleeArgs <- mapM evalTerm $ fromMaybe [] (def ^. ruleArgs)
-        zipWithM_ unify callerArgs calleeArgs
+        zipWithM_ (unify callerSource) callerArgs calleeArgs
         case def ^. ruleBodies of
             -- If there is not a single body, we may have something like
             --
@@ -610,41 +612,55 @@ evalStatement :: Statement SourceSpan -> EvalM Mu'
 evalStatement (UnifyS source x y) = suspend source $ do
     xv <- evalTerm x
     yv <- evalTerm y
-    _  <- unify xv yv
+    _  <- unify source xv yv
     return muTrue
 evalStatement (AssignS source x y) = suspend source $ do
     xv <- evalTerm x
     yv <- evalTerm y
-    _  <- unify xv yv
+    _  <- unify source xv yv
     return muTrue
 evalStatement (TermS e) = suspend (e ^. termAnn) (evalTerm e)
 
 
-unify :: Mu' -> Mu' -> EvalM ()
-unify (Mu WildcardM) _ = return ()
-unify _ (Mu WildcardM) = return ()
-unify (Mu (FreeM alpha)) (Mu (FreeM beta)) =
-    Unification.bindVar alpha beta
-unify (Mu (FreeM alpha)) v = Unification.bindTerm alpha v
-unify v (Mu (FreeM alpha)) = Unification.bindTerm alpha v
-unify (Mu (RecM (ArrayV larr))) (Mu (RecM (ArrayV rarr))) = do
+unify :: SourceSpan -> Mu' -> Mu' -> EvalM ()
+unify _source (Mu WildcardM) _ = return ()
+unify _source _ (Mu WildcardM) = return ()
+unify source (Mu (FreeM alpha)) (Mu (FreeM beta)) =
+    Unification.bindVar source alpha beta
+unify source (Mu (FreeM alpha)) v = Unification.bindTerm source alpha v
+unify source v (Mu (FreeM alpha)) = Unification.bindTerm source alpha v
+unify source (Mu (RecM (ArrayV larr))) (Mu (RecM (ArrayV rarr))) = do
     unifyArrayLength larr rarr
-    V.zipWithM_ unify larr rarr
-unify (Mu (GroundedM (Value (ArrayV larr)))) (Mu (RecM (ArrayV rarr))) = do
+    V.zipWithM_ (unify source) larr rarr
+unify source (Mu (GroundedM (Value (ArrayV larr)))) (Mu (RecM (ArrayV rarr))) = do
     unifyArrayLength larr rarr
-    V.zipWithM_ unify (fmap muValue larr) rarr
-unify (Mu (RecM (ArrayV larr))) (Mu (GroundedM (Value (ArrayV rarr)))) = do
+    V.zipWithM_ (unify source) (fmap muValue larr) rarr
+unify source (Mu (RecM (ArrayV larr))) (Mu (GroundedM (Value (ArrayV rarr)))) = do
     unifyArrayLength larr rarr
-    V.zipWithM_ unify larr (fmap muValue rarr)
-unify (Mu (GroundedM x)) (Mu (GroundedM y)) = unless (x == y) cut
-unify _ _ = cut  -- TODO(jaspervdj): Unify RecM/RecM through ground?
+    V.zipWithM_ (unify source) larr (fmap muValue rarr)
+unify _source (Mu (GroundedM x)) (Mu (GroundedM y)) = unless (x == y) cut
+unify source (Mu (RecM x)) y = do
+    -- This code is currently a bit stricter than it needs to be; it evaluates
+    -- the entire tree in `x` while it would be good enough to "peel off one
+    -- layer" (~ evaluate to whnf) and then try again.
+    gx <- traverse (ground source) x
+    unify source (muValue (Value gx)) y
+unify source x (Mu (RecM y)) = do
+    gy <- traverse (ground source) y
+    unify source x (muValue (Value gy))
+unify source (Mu (TreeM _ _ tree)) y = do
+    gx <- maybe cut pure =<< groundTree source tree
+    unify source (muValue gx) y
+unify source x (Mu (TreeM _ _ tree)) = do
+    gy <- maybe cut pure =<< groundTree source tree
+    unify source x (muValue gy)
 
 
 unifyArrayLength :: V.Vector a -> V.Vector b -> EvalM ()
 unifyArrayLength larr rarr = when (V.length larr /= V.length rarr) cut
 
 
-instance Unification.MonadUnify InstVar (Mu Environment) EvalM where
+instance Unification.MonadUnify SourceSpan InstVar (Mu Environment) EvalM where
     unify = unify
 
     getUnification      = use unification

--- a/lib/Fregot/Parser/Sugar.hs
+++ b/lib/Fregot/Parser/Sugar.hs
@@ -192,7 +192,7 @@ expr = Parsec.buildExpressionParser
     , [ binary Tok.TBinAnd BinAndO Parsec.AssocLeft ]
     , [ binary Tok.TPipe   BinOrO  Parsec.AssocLeft ]
 
-    , [ binary Tok.TEqual    EqualO    Parsec.AssocLeft
+    , [ binary Tok.TEqual    UnifyO    Parsec.AssocLeft
       , binary Tok.TNotEqual NotEqualO Parsec.AssocLeft
       ]
 

--- a/lib/Fregot/Prepare.hs
+++ b/lib/Fregot/Prepare.hs
@@ -342,7 +342,6 @@ prepareBinOp
     -> Sugar.BinOp
     -> ParachuteT Error m BinOp
 prepareBinOp source = \case
-    Sugar.EqualO              -> pure EqualO
     Sugar.NotEqualO           -> pure NotEqualO
     Sugar.LessThanO           -> pure LessThanO
     Sugar.LessThanOrEqualO    -> pure LessThanOrEqualO
@@ -356,17 +355,15 @@ prepareBinOp source = \case
     Sugar.BinAndO             -> pure BinAndO
     Sugar.BinOrO              -> pure BinOrO
     Sugar.UnifyO              -> do
-        tellError $ Error.mkError "compile" source
+        fatal $ Error.mkError "compile" source
             "invalid unification" $
             "The `=` operator should not appear in this context, perhaps" <+>
             "you meant to write `==`?"
-        pure EqualO
     Sugar.AssignO             -> do
-        tellError $ Error.mkError "compile" source
+        fatal $ Error.mkError "compile" source
             "invalid unification" $
             "The `:=` operator should not appear in this context, perhaps" <+>
             "you meant to write `==`?"
-        pure EqualO
 
 prepareWith
     :: Monad m

--- a/lib/Fregot/Prepare/Ast.hs
+++ b/lib/Fregot/Prepare/Ast.hs
@@ -141,8 +141,7 @@ instance Hashable Function
 type Object a = [(Term a, Term a)]
 
 data BinOp
-    = EqualO
-    | NotEqualO
+    = NotEqualO
     | LessThanO
     | LessThanOrEqualO
     | GreaterThanO
@@ -265,7 +264,6 @@ instance PP.Pretty PP.Sem Function where
 
 instance PP.Pretty PP.Sem BinOp where
     pretty = PP.punctuation . \case
-        EqualO              -> "=="
         NotEqualO           -> "!="
         LessThanO           -> "<"
         LessThanOrEqualO    -> "<="

--- a/lib/Fregot/Sugar.hs
+++ b/lib/Fregot/Sugar.hs
@@ -201,7 +201,6 @@ instance (Binary a, Binary n) => Binary (ObjectKey a n)
 data BinOp
     = UnifyO
     | AssignO
-    | EqualO
     | NotEqualO
     | LessThanO
     | LessThanOrEqualO
@@ -384,7 +383,6 @@ instance PP.Pretty PP.Sem BinOp where
     pretty = PP.punctuation . \case
         UnifyO              -> "="
         AssignO             -> ":="
-        EqualO              -> "=="
         NotEqualO           -> "!="
         LessThanO           -> "<"
         LessThanOrEqualO    -> "<="

--- a/tests/golden/invalid/unknown-var-03.rego
+++ b/tests/golden/invalid/unknown-var-03.rego
@@ -6,5 +6,5 @@ double(x) = y {
 
 test_double {
   double(x, y)
-  y == 2
+  y != 2
 }

--- a/tests/golden/opt/simple.stderr
+++ b/tests/golden/opt/simple.stderr
@@ -1,4 +1,4 @@
 [34mdefault[0m allow = [31m[31mfalse[0m[0m
 allow [36m{[0m
-  [36m==[0m[36m([0m[34minput[0m[36m.[0m[31m[31m"root"[0m[0m, [31m[31mtrue[0m[0m[36m)[0m
+  [34minput[0m[36m.[0m[31m[31m"root"[0m[0m [36m=[0m [31m[31mtrue[0m[0m
 [36m}[0m


### PR DESCRIPTION
This gives a few more opportunities for out-vars, so other optimizations are
more likely to kick in.