### PR TITLE
Fix issue in how and when we ground rule indices

### DIFF
--- a/tests/rego/regression-233.rego
+++ b/tests/rego/regression-233.rego
@@ -1,0 +1,14 @@
+# <https://github.com/fugue/fregot/issues/233>
+package test.policy
+
+policies = {"1": {"name": "test"}}
+
+match[policy.name] {
+   policy := policies[input.id]
+   policy.name == input.name
+}
+
+test_match {
+  r := match[_] with input as {"id": "1", "name": "test"}
+  r == "test"
+}


### PR DESCRIPTION
When we have a rule with an index, e.g.:

    match[policy] {
        ...
    }

It's often a good idea to evaluate `policy` first.  That way we can bind that
free variable to whatever the rule is called as.  This gives us instant lookup
if we're calling it as `match["key"]`.

However, if there's a more complicated expression in the index:

    match[policy.name] {
        ...
    }

We must not evaluate the index until after we've evaluated the rule body.

Furthermore, we ensure that we're always returning a grounded `Value` from rule
definitions, rather than a possibly ungrounded `Mu`.

Fixes #233