### PR TITLE
Sort undefined vars in error message

### DIFF
--- a/lib/Fregot/Compile/Package.hs
+++ b/lib/Fregot/Compile/Package.hs
@@ -183,14 +183,12 @@ compileTerm builtins ctree typeContext term0 = do
     safe0 = Safe (HMS.keysSet typeContext)
 
 -- | Designed to match the return type of `orderTermForSafety`.
-runOrder
-    :: (Monad m, PP.Pretty PP.Sem v)
-    => (a, Unsafe v SourceSpan) -> ParachuteT Error m a
+runOrder :: Monad m => (a, Unsafe Var SourceSpan) -> ParachuteT Error m a
 runOrder (x, Unsafe unsafe) = do
-    for_ (sortOn (NonEmpty.head . snd) $ HMS.toList unsafe) $
-        \(var, source :| _) -> tellError $ Error.mkError
-        "compile" source "unknown variable" $
-        "Undefined variable:" <+> PP.pretty var
+    for_ (sortOn (\(v, src :| _) -> (src, unVar v)) $ HMS.toList unsafe) $
+        \(v, src :| _) -> tellError $ Error.mkError
+        "compile" src "unknown variable" $
+        "Undefined variable:" <+> PP.pretty v
     return x
 
 recursionError :: [Rule ty a] -> Error

--- a/lib/Fregot/Compile/Package.hs
+++ b/lib/Fregot/Compile/Package.hs
@@ -15,17 +15,19 @@ module Fregot.Compile.Package
     , valueToCompiledRule
     ) where
 
-import           Control.Lens                      (at, iforM_, review,
-                                                    traverseOf, view, (&), (.~),
-                                                    (^.))
+import           Control.Lens                      (at, review, traverseOf,
+                                                    view, (&), (.~), (^.))
 import           Control.Monad                     (foldM, forM)
 import           Control.Monad.Identity            (runIdentity)
 import           Control.Monad.Parachute           (ParachuteT, catching,
                                                     tellError, tellErrors)
+import           Data.Foldable                     (for_)
 import           Data.Functor                      (($>))
 import qualified Data.Graph                        as Graph
 import qualified Data.HashMap.Strict.Extended      as HMS
 import qualified Data.HashSet.Extended             as HS
+import           Data.List                         (sortOn)
+import qualified Data.List.NonEmpty                as NonEmpty
 import           Data.List.NonEmpty.Extended       (NonEmpty (..))
 import           Data.Proxy                        (Proxy (..))
 import           Data.Traversable.HigherOrder      (htraverse)
@@ -185,7 +187,8 @@ runOrder
     :: (Monad m, PP.Pretty PP.Sem v)
     => (a, Unsafe v SourceSpan) -> ParachuteT Error m a
 runOrder (x, Unsafe unsafe) = do
-    iforM_ unsafe $ \var (source :| _) -> tellError $ Error.mkError
+    for_ (sortOn (NonEmpty.head . snd) $ HMS.toList unsafe) $
+        \(var, source :| _) -> tellError $ Error.mkError
         "compile" source "unknown variable" $
         "Undefined variable:" <+> PP.pretty var
     return x

--- a/tests/golden/invalid/unknown-var-03.rego.stderr
+++ b/tests/golden/invalid/unknown-var-03.rego.stderr
@@ -5,7 +5,7 @@ fregot ([34mcompile error[0m):
     8|   double(x, y)
          [31m^^^^^^^^^^^^[0m
 
-  Undefined variable: x
+  Undefined variable: y
 
 fregot ([34mcompile error[0m):
   "unknown-var-03.rego" (line 8, column 3):
@@ -14,4 +14,4 @@ fregot ([34mcompile error[0m):
     8|   double(x, y)
          [31m^^^^^^^^^^^^[0m
 
-  Undefined variable: y
+  Undefined variable: x


### PR DESCRIPTION
This prevents us from having to update golden tests too often