### PR TITLE
Refactor builtin `Sig` into `TypeRepr`

### DIFF
--- a/fregot.cabal
+++ b/fregot.cabal
@@ -44,6 +44,7 @@ Library
     Fregot.Eval.Number
     Fregot.Eval.TempObject
     Fregot.Eval.Value
+    Fregot.Eval.Value.Conversion
     Fregot.Find
     Fregot.Interpreter
     Fregot.Interpreter.Bundle

--- a/lib/Fregot/Builtins.hs
+++ b/lib/Fregot/Builtins.hs
@@ -20,8 +20,6 @@ module Fregot.Builtins
     ( ToVal (..)
     , FromVal (..)
 
-    , Sig (..)
-
     , Args (..)
     , toArgs
 

--- a/lib/Fregot/Builtins/Base64.hs
+++ b/lib/Fregot/Builtins/Base64.hs
@@ -33,11 +33,11 @@ builtins = HMS.fromList
     ]
 
 encode :: Applicative m => (B.ByteString -> B.ByteString) -> Builtin m
-encode f = Builtin (In Out)
+encode f = Builtin
     (Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons text Nil) -> pure . T.decodeUtf8 . f $! T.encodeUtf8 text
 
 decode :: Applicative m => (B.ByteString -> B.ByteString) -> Builtin m
-decode f = Builtin (In Out)
+decode f = Builtin
     (Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons t Nil) -> pure . T.decodeUtf8 . f $! T.encodeUtf8 t

--- a/lib/Fregot/Builtins/Basics.hs
+++ b/lib/Fregot/Builtins/Basics.hs
@@ -111,7 +111,6 @@ builtins = HMS.fromList
 
 builtin_all :: Monad m => Builtin m
 builtin_all = Builtin
-    (In Out)
     (Ty.collectionOf Ty.boolean 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons arg Nil) -> case arg of
         InL arr -> return $! all (== Value (BoolV True)) (arr :: V.Vector Value)
@@ -119,7 +118,6 @@ builtin_all = Builtin
 
 builtin_any :: Monad m => Builtin m
 builtin_any = Builtin
-    (In Out)
     (Ty.collectionOf Ty.boolean 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons arg Nil) -> case arg of
         InL arr -> return $! any (== Value (BoolV True)) (arr :: V.Vector Value)
@@ -127,14 +125,12 @@ builtin_any = Builtin
 
 builtin_array_concat :: Monad m => Builtin m
 builtin_array_concat = Builtin
-    (In (In Out))
     -- TODO(jaspervdj): We want `∀a b. array<a> -> array<b> -> array<a|b>`.
     (Ty.arrayOf Ty.any 🡒 Ty.arrayOf Ty.any 🡒 Ty.out Ty.unknown) $ pure $
     \(Cons l (Cons r Nil)) -> return (l <> r :: V.Vector Value)
 
 builtin_array_slice :: Monad m => Builtin m
 builtin_array_slice = Builtin
-    (In (In (In Out)))
     (Ty.arrayOf Ty.any 🡒  Ty.number 🡒  Ty.number 🡒 Ty.out (Ty.arrayOf Ty.unknown)) $ pure $
     \(Cons arr (Cons a (Cons b Nil))) -> return $! let
         start = max a 0
@@ -145,20 +141,17 @@ builtin_array_slice = Builtin
 
 builtin_concat :: Monad m => Builtin m
 builtin_concat = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.collectionOf Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons delim (Cons (Values texts) Nil)) ->
     return $! T.intercalate delim texts
 
 builtin_contains :: Monad m => Builtin m
 builtin_contains = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons str (Cons search Nil)) -> return $! search `T.isInfixOf` str
 
 builtin_count :: Monad m => Builtin m
 builtin_count = Builtin
-    (In Out)
     (Ty.collectionOf Ty.any ∪ Ty.string 🡒 Ty.out Ty.number) $ pure $
     \(Cons countee Nil) -> case countee of
         InL (Values c) -> return $! length (c :: [Value])
@@ -166,20 +159,17 @@ builtin_count = Builtin
 
 builtin_endswith :: Monad m => Builtin m
 builtin_endswith = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons str (Cons suffix Nil)) -> return $! suffix `T.isSuffixOf` str
 
 builtin_format_int :: Monad m => Builtin m
 builtin_format_int = Builtin
-    (In (In Out))
     (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.string) $ pure $
     \(Cons x (Cons base Nil)) ->
     return $! T.pack $ showIntAtBase base intToDigit (x :: Int) ""
 
 builtin_indexof :: Monad m => Builtin m
 builtin_indexof = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.number) $ pure $
     \(Cons haystack (Cons needle Nil)) ->
     let (prefix, match) = T.breakOn needle haystack in
@@ -190,7 +180,6 @@ builtin_indexof = Builtin
 
 builtin_intersection :: Monad m => Builtin m
 builtin_intersection = Builtin
-    (In Out)
     -- TODO(jaspervdj): Maybe this should be `∀a. set<set<a>> -> set<a>`.
     (Ty.setOf (Ty.setOf Ty.any) 🡒 Ty.out (Ty.setOf Ty.unknown)) $ pure $
     \(Cons set Nil) -> return $! case HS.toList (set :: (HS.HashSet (HS.HashSet Value))) of
@@ -199,7 +188,6 @@ builtin_intersection = Builtin
 
 builtin_is_array :: Monad m => Builtin m
 builtin_is_array = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         ArrayV _ -> return True
@@ -207,7 +195,6 @@ builtin_is_array = Builtin
 
 builtin_is_boolean :: Monad m => Builtin m
 builtin_is_boolean = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         BoolV _ -> return True
@@ -215,7 +202,6 @@ builtin_is_boolean = Builtin
 
 builtin_is_number :: Monad m => Builtin m
 builtin_is_number = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         NumberV _ -> return True
@@ -223,7 +209,6 @@ builtin_is_number = Builtin
 
 builtin_is_object :: Monad m => Builtin m
 builtin_is_object = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         ObjectV _ -> return True
@@ -231,7 +216,6 @@ builtin_is_object = Builtin
 
 builtin_is_set :: Monad m => Builtin m
 builtin_is_set = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         SetV _ -> return True
@@ -239,7 +223,6 @@ builtin_is_set = Builtin
 
 builtin_is_string :: Monad m => Builtin m
 builtin_is_string = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.boolean) $ pure $
     \(Cons val Nil) -> case unValue val of
         StringV _ -> return True
@@ -247,13 +230,11 @@ builtin_is_string = Builtin
 
 builtin_lower :: Monad m => Builtin m
 builtin_lower = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str Nil) -> return $! T.toLower str
 
 builtin_max :: Monad m => Builtin m
 builtin_max = Builtin
-    (In Out)
     -- TODO(jaspervdj): More like `∀a. collection<a> -> a`.
     (Ty.collectionOf Ty.any 🡒 Ty.out Ty.unknown) $ pure $
     \(Cons (Values vals) Nil) -> return $! case vals of
@@ -262,7 +243,6 @@ builtin_max = Builtin
 
 builtin_min :: Monad m => Builtin m
 builtin_min = Builtin
-    (In Out)
     -- TODO(jaspervdj): More like `∀a. collection<a> -> a`.
     (Ty.collectionOf Ty.any 🡒 Ty.out Ty.unknown) $ pure $
     \(Cons (Values vals) Nil) -> return $! case vals of
@@ -271,7 +251,6 @@ builtin_min = Builtin
 
 builtin_object_filter :: Monad m => Builtin m
 builtin_object_filter = Builtin
-    (In (In Out))
     (Ty.objectOf Ty.any Ty.any 🡒
      Ty.arrayOf Ty.any ∪ Ty.setOf Ty.any ∪ Ty.objectOf Ty.any Ty.any 🡒
      Ty.out (Ty.objectOf Ty.any Ty.any)) $ pure $
@@ -280,7 +259,6 @@ builtin_object_filter = Builtin
 
 builtin_object_remove :: Monad m => Builtin m
 builtin_object_remove = Builtin
-    (In (In Out))
     (Ty.objectOf Ty.any Ty.any 🡒
      Ty.arrayOf Ty.any ∪ Ty.setOf Ty.any ∪ Ty.objectOf Ty.any Ty.any 🡒
      Ty.out (Ty.objectOf Ty.any Ty.any)) $ pure $
@@ -289,32 +267,27 @@ builtin_object_remove = Builtin
 
 builtin_product :: Monad m => Builtin m
 builtin_product = Builtin
-    (In Out)
     (Ty.collectionOf Ty.number 🡒 Ty.out Ty.number) $ pure $
     \(Cons (Values vals) Nil) -> return $! num $ product vals
 
 builtin_replace :: Monad m => Builtin m
 builtin_replace = Builtin
-    (In (In (In Out)))
     (Ty.string 🡒 Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons old (Cons new Nil))) -> return $! T.replace old new str
 
 -- `set()` is OPA's constructor for an empty set, since `{}` is an empty object
 builtin_set :: Monad m => Builtin m
 builtin_set = Builtin
-    Out
     (Ty.out (Ty.setOf Ty.unknown)) $ pure $
     \Nil -> return $! Value $ SetV HS.empty
 
 builtin_split :: Monad m => Builtin m
 builtin_split = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out (Ty.arrayOf Ty.string)) $ pure $
     \(Cons str (Cons delim Nil)) -> return $! T.splitOn delim str
 
 builtin_sprintf :: Monad m => Builtin m
 builtin_sprintf = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.arrayOf Ty.any 🡒 Ty.out Ty.string) $ pure $
     \(Cons format (Cons args Nil)) -> eitherToBuiltinM $
     fmap T.pack $ Printf.sprintf (T.unpack format) $
@@ -322,7 +295,6 @@ builtin_sprintf = Builtin
 
 builtin_substring :: Monad m => Builtin m
 builtin_substring = Builtin
-    (In (In (In Out)))
     (Ty.string 🡒 Ty.number 🡒 Ty.number 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons start (Cons len Nil))) ->
         return $!
@@ -331,26 +303,22 @@ builtin_substring = Builtin
 
 builtin_sum :: Monad m => Builtin m
 builtin_sum = Builtin
-    (In Out)
     (Ty.collectionOf Ty.number 🡒 Ty.out Ty.number) $ pure $
     \(Cons (Values vals) Nil) -> return $! num $ sum vals
 
 builtin_sort :: Monad m => Builtin m
 builtin_sort = Builtin
-    (In Out)
     -- TODO(jaspervdj): Something more akin to `∀a. collection<a> -> array<a>`.
     (Ty.collectionOf Ty.any 🡒 Ty.out (Ty.arrayOf Ty.unknown)) $ pure $
     \(Cons (Values vals) Nil) -> return $! L.sort (vals :: [Value])
 
 builtin_startswith :: Monad m => Builtin m
 builtin_startswith = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.boolean) $ pure $
     (\(Cons str (Cons prefix Nil)) -> return $! prefix `T.isPrefixOf` str)
 
 builtin_to_number :: Monad m => Builtin m
 builtin_to_number = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.number) $ pure $
     \(Cons txt Nil) ->
         let str = T.unpack txt
@@ -362,60 +330,52 @@ builtin_to_number = Builtin
             Just (Right d) -> return $ review Number.double d
 
 builtin_trace :: Monad m => Builtin m
-builtin_trace = Builtin (In Out)
+builtin_trace = Builtin
     (Ty.string 🡒 Ty.out Ty.void) $ pure $
     \(Cons txt Nil) -> liftIO (T.hPutStrLn IO.stderr txt) $> Value NullV
 
 builtin_trim :: Monad m => Builtin m
 builtin_trim = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons cutset Nil)) ->
         return $! T.dropAround (\c -> T.any (== c) cutset) str
 
 builtin_trim_left :: Monad m => Builtin m
 builtin_trim_left = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons cutset Nil)) ->
         return $! T.dropWhile (\c -> T.any (== c) cutset) str
 
 builtin_trim_prefix :: Monad m => Builtin m
 builtin_trim_prefix = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons prefix Nil)) ->
         return $! fromMaybe str $ T.stripPrefix prefix str
 
 builtin_trim_right :: Monad m => Builtin m
 builtin_trim_right = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons cutset Nil)) ->
         return $! T.dropWhileEnd (\c -> T.any (== c) cutset) str
 
 builtin_trim_suffix :: Monad m => Builtin m
 builtin_trim_suffix = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str (Cons suffix Nil)) ->
         return $! fromMaybe str $ T.stripSuffix suffix str
 
 builtin_trim_space :: Monad m => Builtin m
 builtin_trim_space = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str Nil) -> return $! T.dropAround isSpace str
 
 builtin_upper :: Monad m => Builtin m
 builtin_upper = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.string) $ pure $
     \(Cons str Nil) -> return $! T.toUpper str
 
 builtin_union :: Monad m => Builtin m
 builtin_union = Builtin
-    (In Out)
     -- TODO(jaspervdj): Maybe this should be `∀a. set<set<a>> -> set<a>`.
     (Ty.setOf (Ty.setOf Ty.any) 🡒 Ty.out (Ty.setOf Ty.unknown)) $ pure $
     \(Cons set Nil) ->
@@ -423,7 +383,6 @@ builtin_union = Builtin
 
 builtin_walk :: Monad m => Builtin m
 builtin_walk = Builtin
-    (In Out)
     -- TODO(jaspervdj): We could type this way better if we had proper "pair"
     -- array types.
     (Ty.any 🡒 Ty.out (Ty.arrayOf Ty.unknown)) $ pure $
@@ -439,54 +398,52 @@ builtin_walk = Builtin
 
 builtin_not_equal :: Monad m => Builtin m
 builtin_not_equal = Builtin
-  (In (In Out))
   (Ty.any 🡒 Ty.any 🡒 Ty.out Ty.boolean) $ pure $
   \(Cons x (Cons y Nil)) -> return $! Value $ BoolV $! x /= (y :: Value)
 
 builtin_less_than :: Monad m => Builtin m
 builtin_less_than = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.boolean) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x < num y
 
 builtin_less_than_or_equal :: Monad m => Builtin m
 builtin_less_than_or_equal = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.boolean) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x <= num y
 
 builtin_greater_than :: Monad m => Builtin m
 builtin_greater_than = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.boolean) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x > num y
 
 builtin_greater_than_or_equal :: Monad m => Builtin m
 builtin_greater_than_or_equal = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.boolean) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x >= num y
 
 builtin_plus :: Monad m => Builtin m
 builtin_plus = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.number) $ pure $
   \(Cons x (Cons y Nil)) -> return $! num $ x + y
 
 builtin_minus :: Monad m => Builtin m
 builtin_minus = Builtin
-  (In (In Out))
   -- TODO(jaspervdj): Maybe this should be `∀a. set<a> -> set<a> -> set<a>`.
-  (\c (Ty.Cons x (Ty.Cons y Ty.Nil)) ->
-    Ty.bcCatch c
-        (do
-            Ty.bcSubsetOf c x Ty.number
-            Ty.bcSubsetOf c y Ty.number
-            return Ty.number)
-        (do
-            Ty.bcSubsetOf c x $ Ty.setOf Ty.any
-            Ty.bcSubsetOf c y $ Ty.setOf Ty.any
-            return $ Ty.setOf Ty.unknown)) $ pure $
+  (Ty.BuiltinType
+      { Ty.btRepr =
+          Ty.In  (Ty.setOf Ty.any ∪ Ty.number) $
+          Ty.In  (Ty.setOf Ty.any ∪ Ty.number) $
+          Ty.Out (Ty.setOf Ty.any ∪ Ty.number)
+      , Ty.btCheck = \c (Ty.In x (Ty.In y (Ty.Out _))) -> Ty.bcCatch c
+            (do
+                Ty.bcSubsetOf c x Ty.number
+                Ty.bcSubsetOf c y Ty.number
+                return Ty.number)
+            (do
+                Ty.bcSubsetOf c x $ Ty.setOf Ty.any
+                Ty.bcSubsetOf c y $ Ty.setOf Ty.any
+                return $ Ty.setOf Ty.unknown)
+        }) $ pure $
   \(Cons x (Cons y Nil)) -> case (x, y) of
       (InL x', InL y') -> return $! Value $ NumberV $ num $ x' - y'
       (InR x', InR y') -> return $! Value $ SetV $ HS.difference (x' :: HS.HashSet Value) y'
@@ -495,32 +452,27 @@ builtin_minus = Builtin
 
 builtin_times :: Monad m => Builtin m
 builtin_times = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.number) $ pure $
   \(Cons x (Cons y Nil)) -> return $! num $ x * y
 
 builtin_divide :: Monad m => Builtin m
 builtin_divide = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.number) $ pure $
   \(Cons x (Cons y Nil)) -> return $! num $ x / y
 
 builtin_modulo :: Monad m => Builtin m
 builtin_modulo = Builtin
-  (In (In Out))
   (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.number) $ pure $
   \(Cons x (Cons y Nil)) -> return $! x `Number.mod` y
 
 builtin_bin_and :: Monad m => Builtin m
 builtin_bin_and = Builtin
-  (In (In Out))
   -- TODO(jaspervdj): Maybe this should be `∀a. set<a> -> set<a> -> set<a>`.
   (Ty.setOf Ty.any 🡒 Ty.setOf Ty.any 🡒 Ty.out (Ty.setOf Ty.unknown)) $ pure $
   \(Cons x (Cons y Nil)) -> return $! Value $ SetV $ HS.intersection x y
 
 builtin_bin_or :: Monad m => Builtin m
 builtin_bin_or = Builtin
-  (In (In Out))
   -- TODO(jaspervdj): Maybe this should be `∀a. set<a> -> set<a> -> set<a>`.
   (Ty.setOf Ty.any 🡒 Ty.setOf Ty.any 🡒 Ty.out (Ty.setOf Ty.unknown)) $ pure $
   \(Cons x (Cons y Nil)) -> return $! Value $ SetV $ HS.union x y

--- a/lib/Fregot/Builtins/Internal.hs
+++ b/lib/Fregot/Builtins/Internal.hs
@@ -30,8 +30,6 @@ module Fregot.Builtins.Internal
     , (:|:) (..)
     , Json (..)
 
-    , Sig (..)
-
     , Args (..)
     , toArgs
 
@@ -50,182 +48,27 @@ module Fregot.Builtins.Internal
     , Builtins
     ) where
 
-import           Control.Applicative          ((<|>))
-import           Control.Arrow                ((>>>))
-import           Control.Lens                 (preview, review)
 import           Control.Monad.Identity       (Identity)
 import           Control.Monad.Stream         as Stream
-import qualified Data.Aeson                   as Aeson
-import           Data.Bifunctor               (first)
-import           Data.Hashable                (Hashable)
 import qualified Data.HashMap.Strict          as HMS
-import qualified Data.HashSet                 as HS
-import           Data.Int                     (Int64)
-import qualified Data.Text                    as T
-import qualified Data.Text.Lazy               as TL
 import           Data.Traversable.HigherOrder (HTraversable (..))
-import qualified Data.Vector                  as V
 import           Data.Void                    (Void)
-import qualified Fregot.Eval.Json             as Json
-import           Fregot.Eval.Number           (Number)
-import qualified Fregot.Eval.Number           as Number
 import           Fregot.Eval.Value
+import           Fregot.Eval.Value.Conversion
 import           Fregot.Prepare.Ast           (Function (..))
 import qualified Fregot.PrettyPrint           as PP
 import qualified Fregot.Types.Builtins        as Ty
-
-class ToVal a where
-    toVal :: a -> Value
-
-instance ToVal Value where
-    toVal = id
-
-instance ToVal T.Text where
-    toVal = Value . StringV
-
-instance ToVal TL.Text where
-    toVal = toVal . TL.toStrict
-
-instance ToVal Number where
-    toVal = Value . NumberV
-
-instance ToVal Int where
-    toVal = toVal . (fromIntegral :: Int -> Int64)
-
-instance ToVal Int64 where
-    toVal = toVal . review Number.int
-
-instance ToVal Double where
-    toVal = toVal . review Number.double
-
-instance ToVal Bool where
-    toVal = Value . BoolV
-
-instance ToVal a => ToVal (V.Vector a) where
-    toVal = Value . ArrayV . fmap toVal
-
-instance ToVal a => ToVal [a] where
-    toVal = toVal . V.fromList
-
-instance ToVal a => ToVal (HS.HashSet a) where
-    toVal = Value . SetV . HS.map toVal
-
-instance ToVal a => ToVal (HMS.HashMap Value a) where
-    toVal = Value . ObjectV . HMS.map toVal
-
-class FromVal a where
-    fromVal :: Value -> Either String a
-
-instance FromVal Value where
-    fromVal = Right
-
-instance FromVal (HMS.HashMap Value Value) where
-    fromVal (Value (ObjectV o)) = Right o
-    fromVal v                   = Left $
-        "Expected object but got " ++ describeValue v
-
-instance FromVal T.Text where
-    fromVal (Value (StringV t)) = Right t
-    fromVal v                   = Left $
-        "Expected string but got " ++ describeValue v
-
-instance FromVal Number where
-    fromVal (Value (NumberV n)) = Right n
-    fromVal v                   = Left $
-        "Expected number but got " ++ describeValue v
-
-instance FromVal Int where
-    fromVal = fmap (fromIntegral :: Int64 -> Int) . fromVal
-
-instance FromVal Int64 where
-    fromVal (Value (NumberV n)) | Just i <- preview Number.int n = Right i
-    fromVal v                                                    = Left $
-        "Expected int but got " ++ describeValue v
-
-instance FromVal Double where
-    fromVal (Value (NumberV n)) | Just d <- preview Number.double n = Right d
-    fromVal v                                                       =
-        Left $ "Expected double but got " ++ describeValue v
-
-instance FromVal Bool where
-    fromVal (Value (BoolV b)) = Right b
-    fromVal v                 = Left $
-        "Expected bool but got " ++ describeValue v
-
-instance FromVal a => FromVal (V.Vector a) where
-    fromVal (Value (ArrayV v)) = traverse fromVal v
-    fromVal v                  = Left $
-        "Expected array but got " ++ describeValue v
-
-instance FromVal a => FromVal [a] where
-    fromVal = fmap V.toList . fromVal
-
-instance (Eq a, FromVal a, Hashable a) => FromVal (HS.HashSet a)  where
-    fromVal (Value (SetV s)) = fmap HS.fromList $ traverse fromVal (HS.toList s)
-    fromVal v                = Left $ "Expected set but got " ++ describeValue v
-
--- | Sometimes builtins (e.g. `count`) do not take a specific type, but any
--- sort of collection.
-newtype Values a = Values [a]
-
--- | Like `Values`, but collects an object's keys, not values.
-newtype Keys a = Keys [a]
-
-instance FromVal a => FromVal (Values a) where
-    fromVal = unValue >>> \case
-        ArrayV  c -> Values <$> traverse fromVal (V.toList c)
-        SetV    c -> Values <$> traverse fromVal (HS.toList c)
-        ObjectV c -> Values <$> traverse (fromVal . snd) (HMS.toList c)
-        v         -> Left $
-            "Expected values but got " ++ describeValue (Value v)
-
-instance FromVal a => FromVal (Keys a) where
-    fromVal = unValue >>> \case
-        ArrayV  c -> Keys <$> traverse fromVal (V.toList c)
-        SetV    c -> Keys <$> traverse fromVal (HS.toList c)
-        ObjectV c -> Keys <$> traverse (fromVal . fst) (HMS.toList c)
-        v         -> Left $
-            "Expected keys but got " ++ describeValue (Value v)
-
--- | Either-like type for when we have weird ad-hoc polymorphism.
-data a :|: b = InL a | InR b
-
-instance (ToVal a, ToVal b) => ToVal (a :|: b) where
-    toVal (InL x) = toVal x
-    toVal (InR y) = toVal y
-
-instance (FromVal a, FromVal b) => FromVal (a :|: b) where
-    -- TODO(jaspervdj): We should use a datatype for expected result types, so
-    -- we can join them here nicely and not just return the last error message.
-    fromVal v = (InL <$> fromVal v) <|> (InR <$> fromVal v)
-
--- | Convert to and from arguments through an intermediate JSON representation.
-newtype Json a = Json {unJson :: a} deriving (Functor)
-
-instance Aeson.ToJSON a => ToVal (Json a) where
-    toVal = Json.toValue . Aeson.toJSON . unJson
-
-instance Aeson.FromJSON a => FromVal (Json a) where
-    fromVal val = do
-        json <- first show $ Json.fromValue val
-        case Aeson.fromJSON json of
-            Aeson.Error   str -> Left str
-            Aeson.Success p   -> Right (Json p)
-
-data Sig (i :: [t]) (o :: *) where
-    In  :: FromVal a => Sig i o -> Sig (a ': i) o
-    Out :: ToVal o   => Sig '[] o
 
 data Args (a :: [t]) where
     Nil  :: Args '[]
     Cons :: a -> Args as -> Args (a ': as)
 
 -- | TODO (jaspervdj): Use arity check instead?
-toArgs :: Sig t o -> [Value] -> Either String (Args t)
-toArgs Out      []       = return Nil
-toArgs Out      _        = Left "too many arguments supplied"
-toArgs (In _)   []       = Left "not enough arguments supplied"
-toArgs (In sig) (x : xs) = Cons <$> fromVal x <*> toArgs sig xs
+toArgs :: Ty.TypeRepr t o -> [Value] -> Either String (Args t)
+toArgs (Ty.Out _)    []       = return Nil
+toArgs (Ty.Out _)    _        = Left "too many arguments supplied"
+toArgs (Ty.In _ _)   []       = Left "not enough arguments supplied"
+toArgs (Ty.In _ sig) (x : xs) = Cons <$> fromVal x <*> toArgs sig xs
 
 data BuiltinException = BuiltinException PP.SemDoc deriving (Show)
 
@@ -242,21 +85,20 @@ throwDoc = Stream.throw . BuiltinException
 
 -- | A builtin function and its signature.
 data Builtin m where
-    -- TODO(jaspervdj): BuiltinType and Sig are somewhat redundant.
     Builtin
         :: ToVal o
-        => Sig i o -> Ty.BuiltinType i -> m (Args i -> BuiltinM o) -> Builtin m
+        => Ty.BuiltinType i o -> m (Args i -> BuiltinM o) -> Builtin m
 
 instance HTraversable Builtin where
-    htraverse f (Builtin sig ty impl) = Builtin sig ty <$> f impl
+    htraverse f (Builtin ty impl) = Builtin ty <$> f impl
 
 type ReadyBuiltin = Builtin Identity
 
 arity :: Builtin m -> Int
-arity (Builtin sig _ _) = go 0 sig
+arity (Builtin ty _) = go 0 (Ty.btRepr ty)
   where
-    go :: Int -> Sig i o -> Int
-    go !acc Out    = acc
-    go !acc (In s) = go (acc + 1) s
+    go :: Int -> Ty.TypeRepr i o -> Int
+    go !acc (Ty.Out _)  = acc
+    go !acc (Ty.In _ s) = go (acc + 1) s
 
 type Builtins m = HMS.HashMap Function (Builtin m)

--- a/lib/Fregot/Builtins/Json.hs
+++ b/lib/Fregot/Builtins/Json.hs
@@ -32,7 +32,6 @@ builtins = HMS.fromList
 
 builtin_json_marshal :: Monad m => Builtin m
 builtin_json_marshal = Builtin
-    (In Out)
     (Ty.any 🡒 Ty.out Ty.string) $ pure $
     \(Cons val Nil) -> case Json.fromValue val of
         Left err   -> throwDoc err
@@ -40,7 +39,6 @@ builtin_json_marshal = Builtin
 
 builtin_json_unmarshal :: Monad m => Builtin m
 builtin_json_unmarshal = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.unknown) $ pure $
     \(Cons str Nil) -> case A.eitherDecodeStrict' (T.encodeUtf8 str) of
         Left  err -> throwString err

--- a/lib/Fregot/Builtins/Jwt.hs
+++ b/lib/Fregot/Builtins/Jwt.hs
@@ -74,14 +74,14 @@ runJwsM mx = liftIO (runExceptT mx) >>=
     either (\e -> throwString $ "JWS error: " ++ show e) pure
 
 builtin_encode_sign :: Applicative m => Builtin m
-builtin_encode_sign = Builtin (In (In (In Out)))
+builtin_encode_sign = Builtin
     (Ty.any 🡒 Ty.any 🡒 Ty.any 🡒 Ty.out (Ty.string)) $ pure $
     \(Cons (Headers header) (Cons (Payload payload) (Cons (Key key) Nil))) -> do
     signed <- runJwsM $ Jwt.signClaims key header payload
     pure . TL.toStrict . TL.decodeUtf8 $! Jwt.encodeCompact signed
 
 builtin_decode :: Applicative m => Builtin m
-builtin_decode = Builtin (In Out)
+builtin_decode = Builtin
     (Ty.string 🡒 Ty.out (Ty.arrayOf Ty.unknown)) $ pure $
     \(Cons t Nil) -> do
     -- Decode the compact representation.
@@ -166,7 +166,7 @@ instance Aeson.FromJSON Constraints where
         <*> parseValidationSettings obj
 
 builtin_decode_verify :: Applicative m => Builtin m
-builtin_decode_verify = Builtin (In (In Out))
+builtin_decode_verify = Builtin
     (Ty.string 🡒 Ty.any 🡒 Ty.out (Ty.arrayOf Ty.unknown)) $ pure $
     \(Cons t (Cons (Constraints jwk mbTime valSettings) Nil)) -> do
     jws <- runJwsM . Jwt.decodeCompact . TL.encodeUtf8 $! TL.fromStrict t

--- a/lib/Fregot/Builtins/Regex.hs
+++ b/lib/Fregot/Builtins/Regex.hs
@@ -34,7 +34,6 @@ builtins = HMS.fromList
 
 builtin_regex_split :: Builtin IO
 builtin_regex_split = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out (Ty.arrayOf Ty.string)) $ do
     cacheRef <- newIORef HMS.empty
     pure $
@@ -61,7 +60,6 @@ builtin_regex_split = Builtin
 
 builtin_re_match :: Builtin IO
 builtin_re_match = Builtin
-    (In (In Out))
     (Ty.string 🡒 Ty.string 🡒 Ty.out Ty.boolean) $ do
     cacheRef <- newIORef HMS.empty
     pure $

--- a/lib/Fregot/Builtins/Time.hs
+++ b/lib/Fregot/Builtins/Time.hs
@@ -49,13 +49,11 @@ nsToUtc ns =
 
 builtin_time_now_ns :: Monad m => Builtin m
 builtin_time_now_ns = Builtin
-    Out
     (Ty.out Ty.number) $ pure $
     \Nil -> review Number.int . utcToNs <$> liftIO Time.getCurrentTime
 
 builtin_time_date :: Monad m => Builtin m
 builtin_time_date = Builtin
-    (In Out)
     (Ty.number 🡒 Ty.out (Ty.arrayOf Ty.number)) $ pure $
     \(Cons ns Nil) ->
     let utc       = nsToUtc ns
@@ -64,7 +62,6 @@ builtin_time_date = Builtin
 
 builtin_time_parse_rfc3339_ns :: Monad m => Builtin m
 builtin_time_parse_rfc3339_ns = Builtin
-    (In Out)
     (Ty.string 🡒 Ty.out Ty.number) $ pure $
     \(Cons txt Nil) -> case Time.RFC3339.parseTimeRFC3339 txt of
         Just zoned -> return $! utcToNs $ Time.zonedTimeToUTC zoned

--- a/lib/Fregot/Eval.hs
+++ b/lib/Fregot/Eval.hs
@@ -77,6 +77,7 @@ import qualified Fregot.PrettyPrint        as PP
 import           Fregot.Sources.SourceSpan (SourceSpan)
 import           Fregot.Tree               (Tree)
 import qualified Fregot.Tree               as Tree
+import qualified Fregot.Types.Builtins     as Types
 import           Fregot.Types.Rule         (RuleType (..))
 
 ground :: SourceSpan -> Mu' -> EvalM Value
@@ -290,7 +291,7 @@ evalVar _source v = do
 
 
 evalBuiltin :: SourceSpan -> Builtin Identity -> [Mu'] -> EvalM Value
-evalBuiltin source builtin@(Builtin sig _ (Identity impl)) args0 = do
+evalBuiltin source builtin@(Builtin ty (Identity impl)) args0 = do
     -- There are two possible scenarios if we have an N-ary function, e.g.:
     --
     --     add(x, y) = z {
@@ -307,7 +308,7 @@ evalBuiltin source builtin@(Builtin sig _ (Identity impl)) args0 = do
             "arguments but got" <+> PP.pretty n
 
     args2 <- mapM (ground source) args1
-    args3 <- case toArgs sig args2 of
+    args3 <- case toArgs (Types.btRepr ty) args2 of
         Left err -> raise' source "builtin type error" $ PP.pretty err
         Right x  -> return x
 

--- a/lib/Fregot/Eval/Value/Conversion.hs
+++ b/lib/Fregot/Eval/Value/Conversion.hs
@@ -1,0 +1,178 @@
+{-|
+Copyright   : (c) 2020 Fugue, Inc.
+License     : Apache License, version 2.0
+Maintainer  : jasper@fugue.co
+Stability   : experimental
+Portability : POSIX
+
+Conversion from native Haskell values to and from 'Value'.
+-}
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TypeOperators     #-}
+module Fregot.Eval.Value.Conversion
+    ( ToVal (..)
+    , FromVal (..)
+
+    -- `ToVal` / `FromVal` helper newtypes.
+    , Values (..)
+    , Keys (..)
+    , (:|:) (..)
+    , Json (..)
+    ) where
+
+import           Control.Applicative          ((<|>))
+import           Control.Arrow                ((>>>))
+import           Control.Lens                 (preview, review)
+import qualified Data.Aeson                   as Aeson
+import           Data.Bifunctor               (first)
+import qualified Data.HashMap.Strict          as HMS
+import qualified Data.HashSet                 as HS
+import           Data.Hashable                (Hashable)
+import           Data.Int                     (Int64)
+import qualified Data.Text                    as T
+import qualified Data.Text.Lazy               as TL
+import qualified Data.Vector                  as V
+import qualified Fregot.Eval.Json             as Json
+import           Fregot.Eval.Number           (Number)
+import qualified Fregot.Eval.Number           as Number
+import           Fregot.Eval.Value
+
+class ToVal a where
+    toVal :: a -> Value
+
+instance ToVal Value where
+    toVal = id
+
+instance ToVal T.Text where
+    toVal = Value . StringV
+
+instance ToVal TL.Text where
+    toVal = toVal . TL.toStrict
+
+instance ToVal Number where
+    toVal = Value . NumberV
+
+instance ToVal Int where
+    toVal = toVal . (fromIntegral :: Int -> Int64)
+
+instance ToVal Int64 where
+    toVal = toVal . review Number.int
+
+instance ToVal Double where
+    toVal = toVal . review Number.double
+
+instance ToVal Bool where
+    toVal = Value . BoolV
+
+instance ToVal a => ToVal (V.Vector a) where
+    toVal = Value . ArrayV . fmap toVal
+
+instance ToVal a => ToVal [a] where
+    toVal = toVal . V.fromList
+
+instance ToVal a => ToVal (HS.HashSet a) where
+    toVal = Value . SetV . HS.map toVal
+
+instance ToVal a => ToVal (HMS.HashMap Value a) where
+    toVal = Value . ObjectV . HMS.map toVal
+
+class FromVal a where
+    fromVal :: Value -> Either String a
+
+instance FromVal Value where
+    fromVal = Right
+
+instance FromVal (HMS.HashMap Value Value) where
+    fromVal (Value (ObjectV o)) = Right o
+    fromVal v                   = Left $
+        "Expected object but got " ++ describeValue v
+
+instance FromVal T.Text where
+    fromVal (Value (StringV t)) = Right t
+    fromVal v                   = Left $
+        "Expected string but got " ++ describeValue v
+
+instance FromVal Number where
+    fromVal (Value (NumberV n)) = Right n
+    fromVal v                   = Left $
+        "Expected number but got " ++ describeValue v
+
+instance FromVal Int where
+    fromVal = fmap (fromIntegral :: Int64 -> Int) . fromVal
+
+instance FromVal Int64 where
+    fromVal (Value (NumberV n)) | Just i <- preview Number.int n = Right i
+    fromVal v                                                    = Left $
+        "Expected int but got " ++ describeValue v
+
+instance FromVal Double where
+    fromVal (Value (NumberV n)) | Just d <- preview Number.double n = Right d
+    fromVal v                                                       =
+        Left $ "Expected double but got " ++ describeValue v
+
+instance FromVal Bool where
+    fromVal (Value (BoolV b)) = Right b
+    fromVal v                 = Left $
+        "Expected bool but got " ++ describeValue v
+
+instance FromVal a => FromVal (V.Vector a) where
+    fromVal (Value (ArrayV v)) = traverse fromVal v
+    fromVal v                  = Left $
+        "Expected array but got " ++ describeValue v
+
+instance FromVal a => FromVal [a] where
+    fromVal = fmap V.toList . fromVal
+
+instance (Eq a, FromVal a, Hashable a) => FromVal (HS.HashSet a)  where
+    fromVal (Value (SetV s)) = fmap HS.fromList $ traverse fromVal (HS.toList s)
+    fromVal v                = Left $ "Expected set but got " ++ describeValue v
+
+-- | Sometimes builtins (e.g. `count`) do not take a specific type, but any
+-- sort of collection.
+newtype Values a = Values [a]
+
+-- | Like `Values`, but collects an object's keys, not values.
+newtype Keys a = Keys [a]
+
+instance FromVal a => FromVal (Values a) where
+    fromVal = unValue >>> \case
+        ArrayV  c -> Values <$> traverse fromVal (V.toList c)
+        SetV    c -> Values <$> traverse fromVal (HS.toList c)
+        ObjectV c -> Values <$> traverse (fromVal . snd) (HMS.toList c)
+        v         -> Left $
+            "Expected values but got " ++ describeValue (Value v)
+
+instance FromVal a => FromVal (Keys a) where
+    fromVal = unValue >>> \case
+        ArrayV  c -> Keys <$> traverse fromVal (V.toList c)
+        SetV    c -> Keys <$> traverse fromVal (HS.toList c)
+        ObjectV c -> Keys <$> traverse (fromVal . fst) (HMS.toList c)
+        v         -> Left $
+            "Expected keys but got " ++ describeValue (Value v)
+
+-- | Either-like type for when we have weird ad-hoc polymorphism.
+data a :|: b = InL a | InR b
+
+instance (ToVal a, ToVal b) => ToVal (a :|: b) where
+    toVal (InL x) = toVal x
+    toVal (InR y) = toVal y
+
+instance (FromVal a, FromVal b) => FromVal (a :|: b) where
+    -- TODO(jaspervdj): We should use a datatype for expected result types, so
+    -- we can join them here nicely and not just return the last error message.
+    fromVal v = (InL <$> fromVal v) <|> (InR <$> fromVal v)
+
+-- | Convert to and from arguments through an intermediate JSON representation.
+newtype Json a = Json {unJson :: a} deriving (Functor)
+
+instance Aeson.ToJSON a => ToVal (Json a) where
+    toVal = Json.toValue . Aeson.toJSON . unJson
+
+instance Aeson.FromJSON a => FromVal (Json a) where
+    fromVal val = do
+        json <- first show $ Json.fromValue val
+        case Aeson.fromJSON json of
+            Aeson.Error   str -> Left str
+            Aeson.Success p   -> Right (Json p)

--- a/lib/Fregot/Types/Builtins.hs
+++ b/lib/Fregot/Types/Builtins.hs
@@ -13,18 +13,19 @@ Portability : POSIX
 {-# LANGUAGE Rank2Types     #-}
 {-# LANGUAGE TypeOperators  #-}
 module Fregot.Types.Builtins
-    ( InTypes (..)
+    ( TypeRepr (..)
     , BuiltinChecker (..)
-    , BuiltinType
+    , BuiltinType (..)
     , out
     , (🡒)
     ) where
 
+import           Fregot.Eval.Value.Conversion (FromVal, ToVal)
 import           Fregot.Types.Internal
 
-data InTypes (i :: [*]) where
-    Nil  :: InTypes '[]
-    Cons :: Type -> InTypes i -> InTypes (a ': i)
+data TypeRepr (i :: [*]) (o :: *) where
+    Out :: ToVal o   => Type -> TypeRepr '[] o
+    In  :: FromVal a => Type -> TypeRepr i o -> TypeRepr (a ': i) o
 
 data BuiltinChecker m = BuiltinChecker
     { bcUnify    :: Type -> Type -> m Type
@@ -32,12 +33,27 @@ data BuiltinChecker m = BuiltinChecker
     , bcCatch    :: forall a. m a -> m a -> m a
     }
 
-type BuiltinType (i :: [*]) =
-    forall m. Monad m => BuiltinChecker m -> InTypes i -> m Type
+-- | A builtin type has two representations.  One of them is a function that
+-- takes a number of types and returns the return type.  This allows us to do
+-- highly granular type checking.
+--
+-- The other representation is a deep embedding.  This can be used to "print"
+-- the type or render the capabilities doc.  It is also used to convert
+-- arguments to the right shape, so the arities must match.
+data BuiltinType (i :: [*]) (o :: *) = BuiltinType
+    { btCheck :: forall m. Monad m => BuiltinChecker m -> TypeRepr i o -> m Type
+    , btRepr  :: TypeRepr i o
+    }
 
-out :: Type -> BuiltinType '[]
-out t = \_ Nil -> pure t
+out :: ToVal o => Type -> BuiltinType '[] o
+out ty = BuiltinType
+    { btCheck = \_ _ -> pure ty
+    , btRepr  = Out ty
+    }
 
-(🡒) :: Type -> BuiltinType i -> BuiltinType (a ': i)
-(🡒) expect f = \c (Cons actual t) -> bcSubsetOf c actual expect >> f c t
+(🡒) :: FromVal a => Type -> BuiltinType i o -> BuiltinType (a ': i) o
+(🡒) expect bt = BuiltinType
+    { btCheck = \c (In actual t) -> bcSubsetOf c actual expect >> btCheck bt c t
+    , btRepr  = In expect (btRepr bt)
+    }
 infixr 6 🡒

--- a/tests/hs/Fregot/Interpreter/Tests.hs
+++ b/tests/hs/Fregot/Interpreter/Tests.hs
@@ -51,6 +51,5 @@ tests = Tasty.testGroup "Fregot.Interpreter.Tests"
 
     magicImpl :: B.Builtin Identity
     magicImpl = B.Builtin
-        B.Out
         (Types.out Types.number) $
         pure $ \B.Nil -> return $! review Number.int 101

--- a/tests/hs/Fregot/Prepare/Dsl.hs
+++ b/tests/hs/Fregot/Prepare/Dsl.hs
@@ -51,7 +51,6 @@ inferEnv = Types.emptyInferEnv & Types.ieBuiltins .~
   where
     builtin_add :: Monad m => B.Builtin m
     builtin_add = B.Builtin
-        (B.In (B.In B.Out))
         (Ty.number 🡒 Ty.number 🡒 Ty.out Ty.number) $ return $
         \(B.Cons x (B.Cons y B.Nil)) ->
         return ((x :: Number) + (y :: Number) :: Number)


### PR DESCRIPTION
We used to have two indications of a builtins type:

 -  `Sig i o`, which just provided the arity
 -  `BuiltinType i`, which is a closure that checks the type

However, since `Sig` just indicates the arity, it doesn't give us quite enough
information to render the capabilities doc as described in #224.

In this refactor, I extended `Sig` to `TypeRepr` and made it hold more
information: an actual deep embedding of the types.  I also moved this new type
into `BuiltinType` (which is now a record).  This allows convenient construction
of _both_ `TypeRepr` and the checker closure using `🡒` and `out`.