### PR TITLE
[WIP] Detect some rules that are better computed bottom-up

### DIFF
--- a/fregot.cabal
+++ b/fregot.cabal
@@ -74,6 +74,7 @@ Library
     Fregot.Parser.Token
     Fregot.Prepare
     Fregot.Prepare.Ast
+    Fregot.Prepare.BottomUp
     Fregot.Prepare.BuildTree
     Fregot.Prepare.ComprehensionIndex
     Fregot.Prepare.ConstantFold

--- a/fregot.cabal
+++ b/fregot.cabal
@@ -34,6 +34,7 @@ Library
     Fregot.Builtins.Yaml
     Fregot.Capabilities
     Fregot.Compile.Graph
+    Fregot.Compile.Internal
     Fregot.Compile.Order
     Fregot.Compile.Package
     Fregot.Dump

--- a/lib/Control/Monad/Stream.hs
+++ b/lib/Control/Monad/Stream.hs
@@ -16,6 +16,7 @@ module Control.Monad.Stream
     , throw
 
     , toList
+    , fromList
 
     , Step (..)
     , step
@@ -200,6 +201,10 @@ toList (Stream mstep) = do
         SSingle x         -> return $ Right [x]
         SError e          -> return $ Left e
 {-# SPECIALIZE toList :: Stream e i IO a -> IO (Either e [a]) #-}
+
+fromList :: Monad m => [a] -> Stream e i m a
+fromList = foldr (\x s -> Stream $ pure $ SYield x s) (Stream $ pure SDone)
+{-# SPECIALIZE fromList :: [a] -> Stream e i IO a #-}
 
 data Step e i m a
     = Yield   a (Stream e i m a)

--- a/lib/Control/Monad/Stream.hs
+++ b/lib/Control/Monad/Stream.hs
@@ -203,7 +203,7 @@ toList (Stream mstep) = do
 {-# SPECIALIZE toList :: Stream e i IO a -> IO (Either e [a]) #-}
 
 fromList :: Monad m => [a] -> Stream e i m a
-fromList = foldr (\x s -> Stream $ pure $ SYield x s) (Stream $ pure SDone)
+fromList = foldr (\x -> Stream . pure . SYield x) (Stream $ pure SDone)
 {-# SPECIALIZE fromList :: [a] -> Stream e i IO a #-}
 
 data Step e i m a

--- a/lib/Fregot/Compile/Internal.hs
+++ b/lib/Fregot/Compile/Internal.hs
@@ -1,0 +1,39 @@
+{-|
+Copyright   : (c) 2021 Fugue, Inc.
+License     : Apache License, version 2.0
+Maintainer  : jasper@fugue.co
+Stability   : experimental
+Portability : POSIX
+-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+module Fregot.Compile.Internal
+    ( BottomUpInfo (..)
+    , CompiledRuleInfo (..), criType, criBottomUp
+    , CompiledRule
+    ) where
+
+import           Control.Lens              (view)
+import           Control.Lens.TH           (makeLenses)
+import           Fregot.Prepare.Ast        (Rule)
+import           Fregot.Prepare.BottomUp   (BottomUpInfo (..))
+import qualified Fregot.PrettyPrint        as PP
+import           Fregot.Sources.SourceSpan (SourceSpan)
+import           Fregot.Types.Rule
+
+data CompiledRuleInfo = CompiledRuleInfo
+    { _criType     :: !RuleType
+    , _criBottomUp :: !BottomUpInfo
+    } deriving (Show)
+
+$(makeLenses ''CompiledRuleInfo)
+
+instance PP.Pretty PP.Sem CompiledRuleInfo where
+    pretty (CompiledRuleInfo rt bui) = PP.pretty rt PP.<+>?
+        (if bui == BottomUp then Just "bottom-up" else Nothing)
+
+instance HasRuleType CompiledRuleInfo where
+    ruleTypeOf = view criType
+
+type CompiledRule = Rule CompiledRuleInfo SourceSpan

--- a/lib/Fregot/Compile/Order.hs
+++ b/lib/Fregot/Compile/Order.hs
@@ -213,7 +213,7 @@ inferOutVars inferEnv safe mbSource infer =
   where
     maybeInferred =
         snd $ runIdentity $ runParachuteT $
-        Types.runInfer inferEnv {Types._ieInferClosures = False} $ do
+        Types.runInfer inferEnv {Types.ieInferClosures = False} $ do
         for_ mbSource $ \source -> Types.setInferContext source $
             HS.toMap (unSafe safe) $> Types.unknown
         infer

--- a/lib/Fregot/Compile/Package.hs
+++ b/lib/Fregot/Compile/Package.hs
@@ -46,6 +46,7 @@ import qualified Fregot.Error                      as Error
 import           Fregot.Eval.Value                 (Value)
 import           Fregot.Names
 import           Fregot.Prepare.Ast
+import qualified Fregot.Prepare.BottomUp           as BottomUp
 import qualified Fregot.Prepare.ComprehensionIndex as ComprehensionIndex
 import qualified Fregot.Prepare.ConstantFold       as ConstantFold
 import           Fregot.Prepare.Lens
@@ -98,7 +99,9 @@ compileTree builtins ctree0 prep = do
                 (\errs -> if null errs then Nothing else Just errs)
                 (Infer.evalInfer inferEnv $ Infer.inferRule cRule)
                 (\errs -> tellErrors errs $> (rule & ruleInfo .~ ErrorType))
-            let optRule = ComprehensionIndex.rewriteRule inferEnv $
+            let optRule =
+                    BottomUp.rewriteRule $
+                    ComprehensionIndex.rewriteRule inferEnv $
                     ConstantFold.rewriteRule tyRule
             dump "opt" optRule
             return $! inferEnv & Infer.ieTree . at key .~ Just optRule)

--- a/lib/Fregot/Eval/Cache.hs
+++ b/lib/Fregot/Eval/Cache.hs
@@ -75,7 +75,7 @@ $(makeLenses ''Cache)
 
 new :: MonadIO m => m (Cache k v)
 new = liftIO $ Cache
-    <$> IORef.newIORef (C.empty 100)
+    <$> IORef.newIORef (C.empty 2056)
     <*> IORef.newIORef 1
     <*> pure 0
     <*> pure True

--- a/lib/Fregot/Eval/Cache.hs
+++ b/lib/Fregot/Eval/Cache.hs
@@ -22,9 +22,7 @@ module Fregot.Eval.Cache
     , new
     , bump
     , disable
-    , writeSingleton
-    , flushCollection
-    , Result (..)
+    , write
     , read
     ) where
 
@@ -34,10 +32,8 @@ import           Control.Monad          (when)
 import           Control.Monad.Trans    (MonadIO, liftIO)
 import qualified Data.Cache             as C
 import           Data.Hashable          (Hashable)
-import qualified Data.HashMap.Strict    as HMS
 import           Data.IORef.Extended    (IORef)
 import qualified Data.IORef.Extended    as IORef
-import qualified Fregot.Eval.TempObject as TempObject
 import           GHC.Generics           (Generic)
 import           Prelude                hiding (read)
 
@@ -50,22 +46,8 @@ data Versioned k = Versioned {-# UNPACK #-} !Version !k
 
 instance Hashable k => Hashable (Versioned k)
 
--- | Values in the cache.
---
--- NOTE(jaspervdj): Adding a 'None' constructor here to avoid the 'Maybe'
--- indirection may be worth a small speedup.
-data Result v
-    -- | Cached result from a complete rule, can only be a single value.
-    = Singleton !v
-    -- | Cached result from a set or object rule.  The value in the map is
-    -- always true for sets.
-    | Collection !(HMS.HashMap v v)
-    -- | Cached result from a set or object rule, that hasn't been completely
-    -- evaluated, so some values may not be here.
-    | Partial !(TempObject.TempObject v)
-
 data Cache k v = Cache
-    { _cache   :: !(IORef (C.Cache (Versioned k) (Result v)))
+    { _cache   :: !(IORef (C.Cache (Versioned k) v))
     , _next    :: !(IORef Version)
     , _version :: !Version
     , _enabled :: !Bool
@@ -75,7 +57,7 @@ $(makeLenses ''Cache)
 
 new :: MonadIO m => m (Cache k v)
 new = liftIO $ Cache
-    <$> IORef.newIORef (C.empty 2056)
+    <$> IORef.newIORef (C.empty $ 100 * 2056)
     <*> IORef.newIORef 1
     <*> pure 0
     <*> pure True
@@ -90,31 +72,13 @@ disable :: Cache k v -> Cache k v
 disable = enabled .~ False
 
 -- | Add a new singleton result.
-writeSingleton
+write
     :: (Hashable k, Ord k, MonadIO m) => Cache k v -> k -> v -> m ()
-writeSingleton c k val = when (c ^. enabled) $ liftIO $
+write c k result = when (c ^. enabled) $ liftIO $
     IORef.atomicModifyIORef_ (c ^. cache) $
-    C.insert (Versioned (c ^. version) k) (Singleton val)
+    C.insert (Versioned (c ^. version) k) result
 
--- | Indicate that we've traversed the entire collection, so we can change
--- 'Partial' to 'Collection' if necessary.
-flushCollection
-    :: (Hashable k, Ord k, Eq v, Hashable v, MonadIO m)
-    => Cache k v -> k -> m ()
-flushCollection c ck = when (c ^. enabled) $ do
-    c0 <- liftIO $ IORef.readIORef (c ^. cache)
-    case C.lookup vk c0 of
-        Just (Partial pref, _) -> do
-            obj <- TempObject.read pref
-            liftIO $ IORef.atomicModifyIORef_ (c ^. cache) $
-                \c1 -> C.insert vk (Collection obj) c1
-        _ -> pure ()
-  where
-    vk = Versioned (c ^. version) ck
-
-read
-    :: (Hashable k, Ord k, MonadIO m)
-    => Cache k v -> k -> m (Maybe (Result v))
+read :: (Hashable k, Ord k, MonadIO m) => Cache k v -> k -> m (Maybe v)
 read c _ | not (c ^. enabled) = pure Nothing
 read c k = liftIO $
     IORef.atomicModifyIORef' (c ^. cache) $ \c0 ->

--- a/lib/Fregot/Eval/Internal.hs
+++ b/lib/Fregot/Eval/Internal.hs
@@ -35,17 +35,16 @@ import qualified Data.Unification          as Unification
 import           Data.Unique               (Unique)
 import qualified Data.Unique               as Unique
 import           Fregot.Builtins.Internal  (ReadyBuiltin)
+import           Fregot.Compile.Internal   (CompiledRule)
 import qualified Fregot.Error.Stack        as Stack
 import           Fregot.Eval.Cache         (Cache)
 import           Fregot.Eval.Mu            (Mu)
 import           Fregot.Eval.Value         (InstVar, Value)
 import           Fregot.Names              (PackageName, Var)
-import           Fregot.Prepare.Ast        (Function, Rule)
+import           Fregot.Prepare.Ast        (Function)
 import           Fregot.PrettyPrint        ((<+>))
 import qualified Fregot.PrettyPrint        as PP
-import           Fregot.Sources.SourceSpan (SourceSpan)
 import qualified Fregot.Tree               as Tree
-import           Fregot.Types.Rule         (RuleType)
 
 type Mu' = Mu Environment
 
@@ -89,7 +88,7 @@ prettyRowWithContext (Row context value) = PP.vcat $
 
 data Environment = Environment
     { _builtins            :: !(HMS.HashMap Function ReadyBuiltin)
-    , _rules               :: !(Tree.Tree (Rule RuleType SourceSpan))
+    , _rules               :: !(Tree.Tree CompiledRule)
     , _inputDoc            :: !Value
     , _ruleCache           :: !RuleCache
     , _comprehensionCache  :: !ComprehensionCache

--- a/lib/Fregot/Eval/Monad.hs
+++ b/lib/Fregot/Eval/Monad.hs
@@ -72,18 +72,17 @@ import           Control.Monad.Trans       (MonadIO (..))
 import qualified Data.HashMap.Strict       as HMS
 import           Data.List                 (find)
 import           Fregot.Builtins.Internal  (BuiltinException (..))
+import           Fregot.Compile.Package    (CompiledRule)
 import           Fregot.Error              (Error)
 import qualified Fregot.Error              as Error
 import qualified Fregot.Error.Stack        as Stack
 import           Fregot.Eval.Internal
 import           Fregot.Eval.Value
 import           Fregot.Names
-import           Fregot.Prepare.Ast
 import           Fregot.PrettyPrint        ((<$$>))
 import qualified Fregot.PrettyPrint        as PP
 import           Fregot.Sources.SourceSpan (SourceSpan)
 import qualified Fregot.Tree               as Tree
-import           Fregot.Types.Rule         (RuleType)
 
 data EvalException = EvalException Environment Context Error
 
@@ -251,7 +250,7 @@ toInstVar v = state $ \ctx -> case HMS.lookup v (ctx ^. locals) of
             !lcls = HMS.insert v iv (ctx ^. locals) in
         (iv, ctx {_nextInstVar = _nextInstVar ctx + 1, _locals = lcls})
 
-lookupRule :: Name -> EvalM (Maybe (Rule RuleType SourceSpan))
+lookupRule :: Name -> EvalM (Maybe CompiledRule)
 lookupRule (LocalName _) = pure Nothing
 lookupRule (QualifiedName key) = do
     env0 <- ask

--- a/lib/Fregot/Eval/Mu.hs
+++ b/lib/Fregot/Eval/Mu.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (c) 2020 Fugue, Inc.
+Copyright   : (c) 2020-2021 Fugue, Inc.
 License     : Apache License, version 2.0
 Maintainer  : jasper@fugue.co
 Stability   : experimental
@@ -28,19 +28,17 @@ module Fregot.Eval.Mu
     , muToNumber
     ) where
 
-import           Control.Lens              (preview, re)
-import           Data.Maybe                (fromMaybe)
-import qualified Data.Text                 as T
-import           Fregot.Eval.Number        (Number)
+import           Control.Lens            (preview, re)
+import           Data.Maybe              (fromMaybe)
+import qualified Data.Text               as T
+import           Fregot.Compile.Internal (CompiledRule)
+import           Fregot.Eval.Number      (Number)
 import           Fregot.Eval.Value
 import           Fregot.Names
-import           Fregot.Prepare.Ast        (Rule)
-import           Fregot.PrettyPrint        ((<+>))
-import qualified Fregot.PrettyPrint        as PP
-import           Fregot.Sources.SourceSpan (SourceSpan)
-import qualified Fregot.Tree               as Tree
-import           Fregot.Types.Rule         (RuleType)
-import           GHC.Generics              (Generic)
+import           Fregot.PrettyPrint      ((<+>))
+import qualified Fregot.PrettyPrint      as PP
+import qualified Fregot.Tree             as Tree
+import           GHC.Generics            (Generic)
 
 data MuF e a
     = RecM (ValueF a)
@@ -53,7 +51,7 @@ data MuF e a
     --
     -- Having a shallower embedding where we have a tree of lazily (in Haskell)
     -- evaluated rules would prevent us from carrying 'e' here.
-    | TreeM !e !Key !(Tree.Tree (Rule RuleType SourceSpan))
+    | TreeM !e !Key !(Tree.Tree CompiledRule)
     deriving (Foldable, Functor, Generic, Show, Traversable)
 
 instance PP.Pretty PP.Sem a => PP.Pretty PP.Sem (MuF e a) where

--- a/lib/Fregot/Eval/TempObject.hs
+++ b/lib/Fregot/Eval/TempObject.hs
@@ -15,18 +15,25 @@ module Fregot.Eval.TempObject
     , Write (..)
     , write
     , read
+    , negative
+    , isKnownNegative
     ) where
 
 import           Control.Monad.Trans (MonadIO, liftIO)
+import qualified Data.Cache          as Cache
 import           Data.Hashable       (Hashable)
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.IORef          as IORef
 import           Prelude             hiding (read)
 
-type TempObject v = IORef.IORef (HMS.HashMap v v)
+-- | The known key/values that are part of the object, and a cache of values we
+-- know *aren't* in the object.
+data Known v = Known !(HMS.HashMap v v) !(Cache.Cache v ())
+
+type TempObject v = IORef.IORef (Known v)
 
 new :: MonadIO m => HMS.HashMap v v -> m (TempObject v)
-new = liftIO . IORef.newIORef
+new known = liftIO . IORef.newIORef . Known known $ Cache.empty (100 * 1024)
 {-# INLINE new #-}
 
 data Write v = Ok | Duplicate | Inconsistent v
@@ -36,12 +43,23 @@ data Write v = Ok | Duplicate | Inconsistent v
 -- there is already a different value for this key.
 write :: (Eq v, Hashable v, MonadIO m) => TempObject v -> v -> v -> m (Write v)
 write ref k v = liftIO $ IORef.atomicModifyIORef' ref $
-    \obj -> case HMS.lookup k obj of
-        Nothing           -> (HMS.insert k v obj, Ok)
-        Just v' | v == v' -> (obj, Duplicate)
-        Just v'           -> (obj, Inconsistent v')
+    \known@(Known obj negatives) -> case HMS.lookup k obj of
+        Nothing           -> (Known (HMS.insert k v obj) negatives, Ok)
+        Just v' | v == v' -> (known, Duplicate)
+        Just v'           -> (known, Inconsistent v')
 {-# INLINE write #-}
 
 read :: MonadIO m => TempObject v -> m (HMS.HashMap v v)
-read = liftIO . IORef.readIORef
+read = fmap (\(Known known _) -> known) . liftIO . IORef.readIORef
 {-# INLINE read #-}
+
+-- | Mark a value as not being part of the object.
+negative :: (Hashable v, Ord v, MonadIO m) => TempObject v -> v -> m ()
+negative ref k = liftIO $ IORef.atomicModifyIORef' ref $
+    \(Known obj negatives) -> (Known obj (Cache.insert k () negatives), ())
+
+isKnownNegative :: (Hashable v, Ord v, MonadIO m) => TempObject v -> v -> m Bool
+isKnownNegative ref k = liftIO $ IORef.atomicModifyIORef' ref $
+    \known@(Known obj negatives) -> case Cache.lookup k negatives of
+        Nothing              -> (known, False)
+        Just (_, negatives') -> (Known obj negatives', True)

--- a/lib/Fregot/Prepare.hs
+++ b/lib/Fregot/Prepare.hs
@@ -76,7 +76,7 @@ prepareRule pkgname imports rule
             , _ruleAssign   = head ^. Sugar.ruleAssign
             , _ruleKind     = CompleteRule
             , _ruleInfo     = ()
-            , _ruleBottomUp = True
+            , _ruleBottomUp = False
             , _ruleDefs     = []
             }
 

--- a/lib/Fregot/Prepare.hs
+++ b/lib/Fregot/Prepare.hs
@@ -68,15 +68,16 @@ prepareRule pkgname imports rule
         --     composite then it may not contain variables or references.
         def <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage = pkgname
-            , _ruleName    = head ^. Sugar.ruleName
-            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn     = head ^. Sugar.ruleAnn
-            , _ruleDefault = def
-            , _ruleAssign  = head ^. Sugar.ruleAssign
-            , _ruleKind    = CompleteRule
-            , _ruleInfo    = ()
-            , _ruleDefs    = []
+            { _rulePackage  = pkgname
+            , _ruleName     = head ^. Sugar.ruleName
+            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn      = head ^. Sugar.ruleAnn
+            , _ruleDefault  = def
+            , _ruleAssign   = head ^. Sugar.ruleAssign
+            , _ruleKind     = CompleteRule
+            , _ruleInfo     = ()
+            , _ruleBottomUp = True
+            , _ruleDefs     = []
             }
 
     | not (null (head ^. Sugar.ruleArgs)) = do
@@ -100,15 +101,16 @@ prepareRule pkgname imports rule
         index  <- traverse prepareTerm (head ^. Sugar.ruleIndex)
         value  <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage = pkgname
-            , _ruleName    = head ^. Sugar.ruleName
-            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn     = head ^. Sugar.ruleAnn
-            , _ruleDefault = Nothing
-            , _ruleAssign  = head ^. Sugar.ruleAssign
-            , _ruleKind    = FunctionRule (maybe 0 length args)
-            , _ruleInfo    = ()
-            , _ruleDefs    =
+            { _rulePackage  = pkgname
+            , _ruleName     = head ^. Sugar.ruleName
+            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn      = head ^. Sugar.ruleAnn
+            , _ruleDefault  = Nothing
+            , _ruleAssign   = head ^. Sugar.ruleAssign
+            , _ruleKind     = FunctionRule (maybe 0 length args)
+            , _ruleInfo     = ()
+            , _ruleBottomUp = False
+            , _ruleDefs     =
                 [ RuleDefinition
                     { _ruleDefName    = head ^. Sugar.ruleName
                     , _ruleDefImports = imports
@@ -150,15 +152,16 @@ prepareRule pkgname imports rule
         index  <- traverse prepareTerm (head ^. Sugar.ruleIndex)
         value  <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage = pkgname
-            , _ruleName    = head ^. Sugar.ruleName
-            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn     = head ^. Sugar.ruleAnn
-            , _ruleDefault = Nothing
-            , _ruleAssign  = head ^. Sugar.ruleAssign
-            , _ruleKind    = kind
-            , _ruleInfo    = ()
-            , _ruleDefs    =
+            { _rulePackage  = pkgname
+            , _ruleName     = head ^. Sugar.ruleName
+            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn      = head ^. Sugar.ruleAnn
+            , _ruleDefault  = Nothing
+            , _ruleAssign   = head ^. Sugar.ruleAssign
+            , _ruleKind     = kind
+            , _ruleInfo     = ()
+            , _ruleBottomUp = False
+            , _ruleDefs     =
                 [ RuleDefinition
                     { _ruleDefName    = head ^. Sugar.ruleName
                     , _ruleDefImports = imports

--- a/lib/Fregot/Prepare.hs
+++ b/lib/Fregot/Prepare.hs
@@ -68,16 +68,15 @@ prepareRule pkgname imports rule
         --     composite then it may not contain variables or references.
         def <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage  = pkgname
-            , _ruleName     = head ^. Sugar.ruleName
-            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn      = head ^. Sugar.ruleAnn
-            , _ruleDefault  = def
-            , _ruleAssign   = head ^. Sugar.ruleAssign
-            , _ruleKind     = CompleteRule
-            , _ruleInfo     = ()
-            , _ruleBottomUp = False
-            , _ruleDefs     = []
+            { _rulePackage = pkgname
+            , _ruleName    = head ^. Sugar.ruleName
+            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn     = head ^. Sugar.ruleAnn
+            , _ruleDefault = def
+            , _ruleAssign  = head ^. Sugar.ruleAssign
+            , _ruleKind    = CompleteRule
+            , _ruleInfo    = ()
+            , _ruleDefs    = []
             }
 
     | not (null (head ^. Sugar.ruleArgs)) = do
@@ -101,16 +100,15 @@ prepareRule pkgname imports rule
         index  <- traverse prepareTerm (head ^. Sugar.ruleIndex)
         value  <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage  = pkgname
-            , _ruleName     = head ^. Sugar.ruleName
-            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn      = head ^. Sugar.ruleAnn
-            , _ruleDefault  = Nothing
-            , _ruleAssign   = head ^. Sugar.ruleAssign
-            , _ruleKind     = FunctionRule (maybe 0 length args)
-            , _ruleInfo     = ()
-            , _ruleBottomUp = False
-            , _ruleDefs     =
+            { _rulePackage = pkgname
+            , _ruleName    = head ^. Sugar.ruleName
+            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn     = head ^. Sugar.ruleAnn
+            , _ruleDefault = Nothing
+            , _ruleAssign  = head ^. Sugar.ruleAssign
+            , _ruleKind    = FunctionRule (maybe 0 length args)
+            , _ruleInfo    = ()
+            , _ruleDefs    =
                 [ RuleDefinition
                     { _ruleDefName    = head ^. Sugar.ruleName
                     , _ruleDefImports = imports
@@ -152,16 +150,15 @@ prepareRule pkgname imports rule
         index  <- traverse prepareTerm (head ^. Sugar.ruleIndex)
         value  <- traverse prepareTerm (head ^. Sugar.ruleValue)
         pure Rule
-            { _rulePackage  = pkgname
-            , _ruleName     = head ^. Sugar.ruleName
-            , _ruleKey      = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
-            , _ruleAnn      = head ^. Sugar.ruleAnn
-            , _ruleDefault  = Nothing
-            , _ruleAssign   = head ^. Sugar.ruleAssign
-            , _ruleKind     = kind
-            , _ruleInfo     = ()
-            , _ruleBottomUp = False
-            , _ruleDefs     =
+            { _rulePackage = pkgname
+            , _ruleName    = head ^. Sugar.ruleName
+            , _ruleKey     = review qualifiedVarFromKey (pkgname, head ^. Sugar.ruleName)
+            , _ruleAnn     = head ^. Sugar.ruleAnn
+            , _ruleDefault = Nothing
+            , _ruleAssign  = head ^. Sugar.ruleAssign
+            , _ruleKind    = kind
+            , _ruleInfo    = ()
+            , _ruleDefs    =
                 [ RuleDefinition
                     { _ruleDefName    = head ^. Sugar.ruleName
                     , _ruleDefImports = imports
@@ -179,7 +176,10 @@ prepareRule pkgname imports rule
 
 -- | Merge two rules that have the same name.  This can go wrong in all sorts of
 -- ways.
-mergeRules :: Monad m => Rule' -> Rule' -> ParachuteT Error m Rule'
+mergeRules
+    :: (Monad m, Semigroup i)
+    => Rule i SourceSpan -> Rule i SourceSpan
+    -> ParachuteT Error m (Rule i SourceSpan)
 mergeRules x y = do
     let defaults = mapMaybe (view ruleDefault) [x, y]
     when (length defaults > 1) $ tellError $ Error.mkMultiError
@@ -205,6 +205,7 @@ mergeRules x y = do
     return $! x
         & ruleDefault %~ (<|> y ^. ruleDefault)
         & ruleDefs    %~ (++ y ^. ruleDefs)
+        & ruleInfo    %~ (<> y ^. ruleInfo)
 
   where
     compatible ErrorRule _         = True

--- a/lib/Fregot/Prepare/Ast.hs
+++ b/lib/Fregot/Prepare/Ast.hs
@@ -212,12 +212,12 @@ $(makePrisms ''Term)
 
 instance PP.Pretty PP.Sem (Rule i a) where
     pretty r = PP.vcat $
+        (if r ^. ruleBottomUp then ["[bottom-up" <+> name <> "]"] else []) ++
         (case r ^. ruleDefault of Nothing -> []; Just d -> [prettyDefault d]) ++
         map PP.pretty (r ^. ruleDefs)
       where
-        prettyDefault d =
-            PP.keyword "default" <+> PP.pretty (r ^. ruleName) <+> "=" <+>
-            PP.pretty d
+        name = PP.pretty $ r ^. ruleName
+        prettyDefault d = PP.keyword "default" <+> name <+> "=" <+> PP.pretty d
 
 instance PP.Pretty PP.Sem (RuleDefinition a) where
     pretty rdef =

--- a/lib/Fregot/Prepare/BottomUp.hs
+++ b/lib/Fregot/Prepare/BottomUp.hs
@@ -21,7 +21,9 @@ rewriteRule :: Rule i SourceSpan -> Rule i SourceSpan
 rewriteRule rule = rule & ruleBottomUp .~ bottomUpRule rule
 
 bottomUpRule :: Rule i a -> Bool
-bottomUpRule = allOf (ruleDefs . traverse) bottomUpRuleDefinition
+bottomUpRule rule =
+    (rule ^. ruleKind == GenObjectRule || rule ^. ruleKind == GenSetRule) &&
+    allOf (ruleDefs . traverse) bottomUpRuleDefinition rule
 
 bottomUpRuleDefinition :: RuleDefinition a -> Bool
 bottomUpRuleDefinition rdef =

--- a/lib/Fregot/Prepare/BottomUp.hs
+++ b/lib/Fregot/Prepare/BottomUp.hs
@@ -1,0 +1,72 @@
+{-|
+Copyright   : (c) 2021 Fugue, Inc.
+License     : Apache License, version 2.0
+Maintainer  : jasper@fugue.co
+Stability   : experimental
+Portability : POSIX
+-}
+{-# LANGUAGE LambdaCase #-}
+module Fregot.Prepare.BottomUp
+    ( rewriteRule
+    ) where
+
+import           Control.Lens              (allOf, anyOf, (&), (.~), (^.), _2)
+import           Data.Maybe                (isNothing)
+import           Fregot.Names
+import           Fregot.Prepare.Ast
+import           Fregot.Prepare.Lens
+import           Fregot.Sources.SourceSpan (SourceSpan)
+
+rewriteRule :: Rule i SourceSpan -> Rule i SourceSpan
+rewriteRule rule = rule & ruleBottomUp .~ bottomUpRule rule
+
+bottomUpRule :: Rule i a -> Bool
+bottomUpRule = allOf (ruleDefs . traverse) bottomUpRuleDefinition
+
+bottomUpRuleDefinition :: RuleDefinition a -> Bool
+bottomUpRuleDefinition rdef =
+    bottomUpVar (rdef ^. ruleIndex) && bottomUpVar (rdef ^. ruleValue) &&
+    null (rdef ^. ruleElses) && isNothing (rdef ^. ruleArgs)
+  where
+    bottomUpVar Nothing = True
+    bottomUpVar (Just (NameT _ (LocalName var))) =
+        allOf (ruleBodies . traverse) ((== Yes) . assignedOnceRuleBody var) rdef
+    bottomUpVar (Just _) = False
+
+data AssignedOnce = Yes | No | Unknown deriving (Eq)
+
+instance Semigroup AssignedOnce where
+    Yes     <> Yes     = No
+    No      <>  _      = No
+    _       <> No      = No
+    x       <> Unknown = x
+    Unknown <> y       = y
+
+instance Monoid AssignedOnce where
+    mempty = Unknown
+
+assignedOnceRuleBody :: Var -> RuleBody a -> AssignedOnce
+assignedOnceRuleBody var = foldMap (assignedOnceLiteral var)
+
+assignedOnceLiteral :: Var -> Literal a -> AssignedOnce
+assignedOnceLiteral var lit
+    | appearsInWith = No
+    | otherwise     = assignedOnceStatement var $ lit ^. literalStatement
+  where
+    appearsInWith =
+        anyOf (literalWith . traverse . withAs) (appearsInTerm var) lit
+
+assignedOnceStatement :: Var -> Statement a -> AssignedOnce
+assignedOnceStatement var = \case
+    UnifyS _ (NameT _ (LocalName v)) _ | v == var -> Yes
+    UnifyS _ _ (NameT _ (LocalName v)) | v == var -> Yes
+    UnifyS _ l r ->
+        if appearsInTerm var l || appearsInTerm var r then No else Unknown
+    AssignS _ (NameT _ (LocalName v)) _ | v == var -> Yes
+    AssignS _ _ r ->
+        if appearsInTerm var r then No else Unknown
+    TermS t -> if appearsInTerm var t then No else Unknown
+    IndexedCompS _ _ -> No
+
+appearsInTerm :: Var -> Term a -> Bool
+appearsInTerm v term = anyOf (termCosmosNames . _2 . _LocalName) (== v) term

--- a/lib/Fregot/Prepare/BottomUp.hs
+++ b/lib/Fregot/Prepare/BottomUp.hs
@@ -7,18 +7,23 @@ Portability : POSIX
 -}
 {-# LANGUAGE LambdaCase #-}
 module Fregot.Prepare.BottomUp
-    ( rewriteRule
+    ( BottomUpInfo (..)
+    , addBottomUpInfo
     ) where
 
-import           Control.Lens              (allOf, anyOf, (&), (.~), (^.), _2)
+import           Control.Lens              (allOf, anyOf, (&), (^.), _2, (%~))
 import           Data.Maybe                (isNothing)
 import           Fregot.Names
 import           Fregot.Prepare.Ast
 import           Fregot.Prepare.Lens
 import           Fregot.Sources.SourceSpan (SourceSpan)
 
-rewriteRule :: Rule i SourceSpan -> Rule i SourceSpan
-rewriteRule rule = rule & ruleBottomUp .~ bottomUpRule rule
+data BottomUpInfo = BottomUp | TopDown deriving (Eq, Show)
+
+addBottomUpInfo :: Rule i SourceSpan -> Rule (i, BottomUpInfo) SourceSpan
+addBottomUpInfo rule =
+    let info = if bottomUpRule rule then BottomUp else TopDown in
+    rule & ruleInfo %~ (\i -> (i, info))
 
 bottomUpRule :: Rule i a -> Bool
 bottomUpRule rule =

--- a/lib/Fregot/Prepare/Lens.hs
+++ b/lib/Fregot/Prepare/Lens.hs
@@ -51,6 +51,7 @@ ruleTerms f rule = Rule
     <*> pure (rule ^. ruleInfo)
     <*> traverse f (rule ^. ruleDefault)
     <*> pure (rule ^. ruleAssign)
+    <*> pure (rule ^. ruleBottomUp)
     <*> traverseOf (traverse . ruleDefinitionTerms) f (rule ^. ruleDefs)
 
 -- All rule "bodies" inside a rule.  Useful for optimizations.  Does not include

--- a/lib/Fregot/Prepare/Lens.hs
+++ b/lib/Fregot/Prepare/Lens.hs
@@ -32,11 +32,12 @@ module Fregot.Prepare.Lens
     ) where
 
 import           Control.Lens        (Fold, Lens', Prism', Traversal', aside,
-                                      lens, prism', to, traverseOf, (^.), _2, preview, _Right)
+                                      lens, preview, prism', to, traverseOf,
+                                      (^.), _2, _Right)
 import           Control.Lens.Plated (Plated (..), cosmos, cosmosOnOf)
+import           Data.Scientific     (Scientific, floatingOrInteger)
 import           Fregot.Eval.Number  as Number
 import           Fregot.Eval.Value   (Value (..), ValueF (..))
-import Data.Scientific (Scientific, floatingOrInteger)
 import           Fregot.Names
 import           Fregot.Prepare.Ast
 
@@ -51,7 +52,6 @@ ruleTerms f rule = Rule
     <*> pure (rule ^. ruleInfo)
     <*> traverse f (rule ^. ruleDefault)
     <*> pure (rule ^. ruleAssign)
-    <*> pure (rule ^. ruleBottomUp)
     <*> traverseOf (traverse . ruleDefinitionTerms) f (rule ^. ruleDefs)
 
 -- All rule "bodies" inside a rule.  Useful for optimizations.  Does not include

--- a/lib/Fregot/Types/Rule.hs
+++ b/lib/Fregot/Types/Rule.hs
@@ -1,5 +1,5 @@
 {-|
-Copyright   : (c) 2020 Fugue, Inc.
+Copyright   : (c) 2020-2021 Fugue, Inc.
 License     : Apache License, version 2.0
 Maintainer  : jasper@fugue.co
 Stability   : experimental
@@ -11,9 +11,12 @@ module Fregot.Types.Rule
     ( RuleType (..), _CompleteRuleType, _GenSetRuleType, _GenObjectRuleType
     , _FunctionType
     , ruleTypeToType
+
+    , HasRuleType (..)
     ) where
 
 import           Control.Lens.TH       (makePrisms)
+import           Data.Void             (Void, absurd)
 import qualified Fregot.Prepare.Ast    as Ast
 import qualified Fregot.PrettyPrint    as PP
 import           Fregot.Types.Internal
@@ -38,3 +41,10 @@ ruleTypeToType (FunctionType _)        = void
 ruleTypeToType ErrorType               = unknown
 
 $(makePrisms ''RuleType)
+
+-- | Used to abstract around meta-information for rules.
+class HasRuleType info where
+    ruleTypeOf :: info -> RuleType
+
+instance HasRuleType Void where
+    ruleTypeOf = absurd

--- a/tests/golden/opt/bottom-up.rego
+++ b/tests/golden/opt/bottom-up.rego
@@ -1,0 +1,15 @@
+package bottom_up
+
+primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]
+
+double_primes[ret] {
+  # Should be bottom up, `ret` only assigned.
+  primes[p]
+  ret := p * 2
+}
+
+small_primes[ret] {
+  # Should not be bottom up because of the restriction on `ret`.
+  ret := primes[_]
+  ret < 10
+}

--- a/tests/golden/opt/bottom-up.stderr
+++ b/tests/golden/opt/bottom-up.stderr
@@ -1,3 +1,30 @@
+[primes array{
+  0: number,
+  16: number,
+  1: number,
+  17: number,
+  2: number,
+  18: number,
+  3: number,
+  19: number,
+  4: number,
+  20: number,
+  5: number,
+  21: number,
+  6: number,
+  22: number,
+  7: number,
+  23: number,
+  8: number,
+  24: number,
+  9: number,
+  10: number,
+  11: number,
+  12: number,
+  13: number,
+  14: number,
+  15: number
+}]
 primes = [
   2,
   3,
@@ -25,11 +52,12 @@ primes = [
   89,
   97
 ]
-[bottom-up double_primes]
+[double_primes set{number} bottom-up]
 double_primes [ret] {
   bottom_up.primes.p
   ret := *(p, 2)
 }
+[small_primes set{number}]
 small_primes [ret] {
   ret := bottom_up.primes._
   <(ret, 10)

--- a/tests/golden/opt/bottom-up.stderr
+++ b/tests/golden/opt/bottom-up.stderr
@@ -1,0 +1,36 @@
+primes = [
+  2,
+  3,
+  5,
+  7,
+  11,
+  13,
+  17,
+  19,
+  23,
+  29,
+  31,
+  37,
+  41,
+  43,
+  47,
+  53,
+  59,
+  61,
+  67,
+  71,
+  73,
+  79,
+  83,
+  89,
+  97
+]
+[bottom-up double_primes]
+double_primes [ret] {
+  bottom_up.primes.p
+  ret := *(p, 2)
+}
+small_primes [ret] {
+  ret := bottom_up.primes._
+  <(ret, 10)
+}

--- a/tests/golden/opt/comprehension-index.stderr
+++ b/tests/golden/opt/comprehension-index.stderr
@@ -1,3 +1,21 @@
+[mock_input object{"exposed": array{
+  0: object{
+    "interface": string,
+    "port": number
+  },
+  1: object{
+    "interface": string,
+    "port": number
+  },
+  2: object{
+    "interface": string,
+    "port": number
+  },
+  3: object{
+    "interface": string,
+    "port": number
+  }
+}}]
 mock_input = {"exposed": [
   {
     "port": 8080,
@@ -16,6 +34,7 @@ mock_input = {"exposed": [
     "interface": "lo1"
   }
 ]}
+[exposed_ports_by_interface object{string: array{number: number}}]
 exposed_ports_by_interface [intf] = ports {
   intf := comprehension_index.mock_input."exposed".i."interface"
   [index intf] ports := [port |
@@ -23,11 +42,12 @@ exposed_ports_by_interface [intf] = ports {
     port := comprehension_index.mock_input."exposed".j."port"
   ]
 }
-[bottom-up deny]
+[deny set{string} bottom-up]
 deny [msg] {
   >(count(comprehension_index.exposed_ports_by_interface.i), 1)
   msg := sprintf("interface '%v' exposes too many ports", [i])
 }
+[test_deny boolean]
 test_deny {
   comprehension_index.deny."interface 'eth0' exposes too many ports" with input. as comprehension_index.mock_input
 }

--- a/tests/golden/opt/comprehension-index.stderr
+++ b/tests/golden/opt/comprehension-index.stderr
@@ -23,6 +23,7 @@ exposed_ports_by_interface [intf] = ports {
     port := comprehension_index.mock_input."exposed".j."port"
   ]
 }
+[bottom-up deny]
 deny [msg] {
   >(count(comprehension_index.exposed_ports_by_interface.i), 1)
   msg := sprintf("interface '%v' exposes too many ports", [i])

--- a/tests/golden/opt/opa-2497.stderr
+++ b/tests/golden/opt/opa-2497.stderr
@@ -1,8 +1,14 @@
+[english object{
+  "one": number,
+  "two": number,
+  "three": number
+}]
 english = {
   "three": 3,
   "one": 1,
   "two": 2
 }
+[should_be_1 set{number}]
 should_be_1 = ret {
   textual = "one"
   numeric = 1
@@ -14,6 +20,7 @@ should_be_1 = ret {
     ])
   }
 }
+[test_should_be_1 boolean]
 test_should_be_1 {
   bug.should_be_1 = {1}
 }

--- a/tests/golden/opt/simple.stderr
+++ b/tests/golden/opt/simple.stderr
@@ -1,3 +1,4 @@
+[allow boolean]
 default allow = false
 allow {
   input."root" = true


### PR DESCRIPTION
This adds new `BottomUp` module that attempts to identify rules that are better
computed in a bottom-up way.  The results are stored in a new `CompiledRuleInfo`
type that is attached to rules (the `i` in `Rule i a`).

Specifically, it identifies rules that do not take advantage from shortcutting
on the key:

    rule[k] {
      k := 2
    }

Since `k` is always assigned a single value, we know that top-down evaluation
will not be able to short-circuit based on the argument.  This is not the case
for these examples:

    rule[k] {
      k > 2  # May short-circuit anything below
      ...
    }

    rule[k] {
      v := some_object[k]  # May ignore most of `some_object`
      ...
    }

We error on the side of caution and only allow the optimization when a the key
is assigned exactly once and does not appear in other (possibly grounded)
places in the rule.
