### PR TITLE
Delay union on array types

### DIFF
--- a/lib/Fregot/Types/Infer.hs
+++ b/lib/Fregot/Types/Infer.hs
@@ -639,7 +639,7 @@ unifyTermType source (NameT _ (LocalName α)) σ = void $
     Unify.bindTerm source α σ
 
 unifyTermType source (ArrayT _ arr) (τ, s)
-        | Just sd <- τ ^? Types.singleton . Types._Array =
+        | Just sd <- Types.unArray τ =
     ifor_ arr $ \i t ->
         let σ = fromMaybe Types.unknown $ Types.sdLookup i sd in
         unifyTermType source t (σ, s)


### PR DESCRIPTION
The typechecker is a bit to eager in #292 to turn something like:

    array<A> | array<B>

Into:

    array<A|B>

In most cases this is fine, but sometimes you want the former, especially if
you're using an array as a tuple where the first field may be a discriminator.

This PR fixes that by not unifying the arrays, and just deconstructing it
later when necessary.