### PR TITLE
Relax constraints around ref unification

### DIFF
--- a/tests/rego/types-03.rego
+++ b/tests/rego/types-03.rego
@@ -1,0 +1,10 @@
+package types_03
+
+test_union {
+  datas := {
+      {"number": 1},
+      1
+  }
+  d := datas[_]
+  d.number == 1
+}


### PR DESCRIPTION
When unifying ref[x], and ref has a union type, only require the ref to match
against one of the options rather than all of them.